### PR TITLE
Prefer exact basename matches over shallow matches

### DIFF
--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -26,3 +26,6 @@ describe "filtering", ->
 
       candidates = ['/bar/foo', 'bar/////////']
       expect(filter(candidates, 'bar', maxResults: 1)).toEqual ['bar/////////']
+
+    it "prefers basename matches over shallow matches", ->
+      expect(filter(['foo/quix.js', 'foo/bar/baz/quix'], 'quix', maxResults: 1)).toEqual ['foo/bar/baz/quix']

--- a/src/filter.coffee
+++ b/src/filter.coffee
@@ -25,7 +25,7 @@ basenameScore = (string, query, score) ->
 
   # Shallow files are scored higher
   segmentCount = slashCount + 1
-  depth = Math.max(1, 10 - segmentCount)
+  depth = Math.max(1, segmentCount * -1)
   score *= depth * 0.01
   score
 


### PR DESCRIPTION
The idea is to prefer an exact basename match, even if that match is deeper/has more segments. The test demonstrates:

``` coffee-script
it "prefers basename matches over shallow matches", ->
  expect(filter(['foo/quix.js', 'foo/bar/baz/quix'], 'quix', maxResults: 1)).toEqual ['foo/bar/baz/quix']
```
