### PR TITLE
Fix scoring to favor exact substring matches

### DIFF
--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -15,13 +15,13 @@ rootPath = (segments...) ->
 
 describe "filtering", ->
   it "returns an array of the most accurate results", ->
-    candidates = ['Gruntfile','filter', 'bile', null, '', undefined]
-    expect(filter(candidates, 'file')).toEqual ['filter', 'Gruntfile']
+    candidates = ['Gruntfile', 'filter', 'bile', null, '', undefined]
+    expect(filter(candidates, 'file')).toEqual ['Gruntfile', 'filter']
 
   describe "when the maxResults option is set", ->
     it "limits the results to the result size", ->
       candidates = ['Gruntfile', 'filter', 'bile']
-      expect(bestMatch(candidates, 'file')).toBe 'filter'
+      expect(bestMatch(candidates, 'file')).toBe 'Gruntfile'
 
   describe "when the entries contains slashes", ->
     it "weighs basename matches higher", ->
@@ -111,6 +111,9 @@ describe "filtering", ->
     expect(bestMatch(['a_b_c', 'a_b'], 'ab')).toBe 'a_b'
     expect(bestMatch(['z_a_b', 'a_b'], 'ab')).toBe 'a_b'
     expect(bestMatch(['a_b_c', 'c_a_b'], 'ab')).toBe 'a_b_c'
+
+  it "weights matches that are substring matches higher", ->
+    expect(bestMatch(['/a/b/c/install.txt', 'inst-all.txt'])).toBe '/a/b/c/install.txt'
 
   describe "when the entries are of differing directory depths", ->
     it "places exact matches first, even if they're deeper", ->

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -112,7 +112,7 @@ describe "filtering", ->
     expect(bestMatch(['z_a_b', 'a_b'], 'ab')).toBe 'a_b'
     expect(bestMatch(['a_b_c', 'c_a_b'], 'ab')).toBe 'a_b_c'
 
-  it "weights matches that are substring matches higher", ->
+  it "weighs matches that are substring matches higher", ->
     expect(bestMatch(['/a/b/c/install.txt', 'inst-all.txt'])).toBe '/a/b/c/install.txt'
 
   describe "when the entries are of differing directory depths", ->

--- a/src/filter.coffee
+++ b/src/filter.coffee
@@ -13,6 +13,7 @@ module.exports = (candidates, query, queryHasSlashes, {key, maxResults}={}) ->
       score = scorer.score(string, query, queryHasSlashes)
       unless queryHasSlashes
         score = scorer.basenameScore(string, query, score)
+      score = scorer.substringScore(string, query, score)
       scoredCandidates.push({candidate, score}) if score > 0
 
     # Sort scores in descending order

--- a/src/fuzzaldrin.coffee
+++ b/src/fuzzaldrin.coffee
@@ -21,6 +21,7 @@ module.exports =
     query = query.replace(SpaceRegex, '')
     score = scorer.score(string, query)
     score = scorer.basenameScore(string, query, score) unless queryHasSlashes
+    score = scorer.substringScore(string, query, score)
     score
 
   match: (string, query) ->

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -42,6 +42,22 @@ exports.basenameScore = (string, query, score) ->
   score *= depth * 0.01
   score
 
+exports.substringScore = (string, query, score) ->
+  # Return a near perfect score if the query is a substring match
+  substrIndex = string.indexOf(query)
+  substrIndexi = string.toLowerCase().indexOf(query.toLowerCase())
+
+  if substrIndex >= 0
+    return score + 1.155 if substrIndex == 0
+    return score + 1.145 if string[substrIndex - 1] == PathSeparator
+    return score + 1.135
+  else if substrIndexi >= 0
+    return score + 1.15 if substrIndexi == 0
+    return score + 1.14 if string[substrIndexi - 1] == PathSeparator
+    return score + 1.13
+
+  return score
+
 exports.score = (string, query) ->
   return 1 if string is query
 


### PR DESCRIPTION
So I made pretty radical changes to scoring and don't expect this to be accepted without tweaks, but I figured it would be a good way to get momentum on the problem.

We have an issue with exact substring matches being scored lower than non substring matches. My go to example is:

> Find And Replace: Select All
> Settings View: Install Packages And Themes

That's the sorted order when searching for "Install", clearly not what you'd expect. This changes the scoring system to heavily weight substring matches, so if you type a word exactly as it appears in the string, it will be weighted highly (nearly as a high as an exact match).

Should address https://github.com/atom/atom/issues/6461 and https://github.com/atom/command-palette/issues/28.