### PR TITLE
attempt to improve search pertinence

### DIFF
--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -111,8 +111,8 @@ describe "filtering", ->
     expect(bestMatch(['a_b_c', 'a_b'], 'ab')).toBe 'a_b'
     expect(bestMatch(['z_a_b', 'a_b'], 'ab')).toBe 'a_b'
     expect(bestMatch(['a_b_c', 'c_a_b'], 'ab')).toBe 'a_b_c'
-    expect(bestMatch(['Unin-stall', 'dir1/dir2/dir3/Installation'], 'install')).toBe 'dir1/dir2/dir3/Installation'
-    expect(bestMatch(['Uninstall', 'dir/Install'], 'install')).toBe 'dir/Install'
+    expect(bestMatch(['Unin-stall', 'dir1' + path.sep + 'dir2' + path.sep + 'dir3' + path.sep + 'Installation'], 'install')).toBe 'dir1' + path.sep + 'dir2' + path.sep + 'dir3' + path.sep + 'Installation'
+    expect(bestMatch(['Uninstall', 'dir' + path.sep + 'Install'], 'install')).toBe 'dir' + path.sep + 'Install'
 
   it "weighs substring higher than individual characters", ->
     expect(bestMatch(['a_b_c', 'somethingabc'], 'abc')).toBe 'somethingabc'

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -111,8 +111,8 @@ describe "filtering", ->
     expect(bestMatch(['a_b_c', 'a_b'], 'ab')).toBe 'a_b'
     expect(bestMatch(['z_a_b', 'a_b'], 'ab')).toBe 'a_b'
     expect(bestMatch(['a_b_c', 'c_a_b'], 'ab')).toBe 'a_b_c'
-    expect(bestMatch(['Unin-stall', 'dir1' + path.sep + 'dir2' + path.sep + 'dir3' + path.sep + 'Installation'], 'install')).toBe 'dir1' + path.sep + 'dir2' + path.sep + 'dir3' + path.sep + 'Installation'
-    expect(bestMatch(['Uninstall', 'dir' + path.sep + 'Install'], 'install')).toBe 'dir' + path.sep + 'Install'
+    expect(bestMatch(['Unin-stall', path.join('dir1', 'dir2', 'dir3', 'Installation')], 'install')).toBe path.join('dir1', 'dir2', 'dir3', 'Installation')
+    expect(bestMatch(['Uninstall', path.join('dir', 'Install')], 'install')).toBe path.join('dir', 'Install')
 
   it "weighs substring higher than individual characters", ->
     candidates = [

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -16,12 +16,12 @@ rootPath = (segments...) ->
 describe "filtering", ->
   it "returns an array of the most accurate results", ->
     candidates = ['Gruntfile','filter', 'bile', null, '', undefined]
-    expect(filter(candidates, 'file')).toEqual ['filter', 'Gruntfile']
+    expect(filter(candidates, 'file')).toEqual ['Gruntfile', 'filter']
 
   describe "when the maxResults option is set", ->
     it "limits the results to the result size", ->
       candidates = ['Gruntfile', 'filter', 'bile']
-      expect(bestMatch(candidates, 'file')).toBe 'filter'
+      expect(bestMatch(candidates, 'file')).toBe 'Gruntfile'
 
   describe "when the entries contains slashes", ->
     it "weighs basename matches higher", ->
@@ -111,6 +111,11 @@ describe "filtering", ->
     expect(bestMatch(['a_b_c', 'a_b'], 'ab')).toBe 'a_b'
     expect(bestMatch(['z_a_b', 'a_b'], 'ab')).toBe 'a_b'
     expect(bestMatch(['a_b_c', 'c_a_b'], 'ab')).toBe 'a_b_c'
+    expect(bestMatch(['Unin-stall', 'dir1/dir2/dir3/Installation'], 'install')).toBe 'dir1/dir2/dir3/Installation'
+    expect(bestMatch(['Uninstall', 'dir/Install'], 'install')).toBe 'dir/Install'
+
+  it "weighs substring higher than individual characters", ->
+    expect(bestMatch(['a_b_c', 'somethingabc'], 'abc')).toBe 'somethingabc'
 
   describe "when the entries are of differing directory depths", ->
     it "places exact matches first, even if they're deeper", ->

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -115,6 +115,13 @@ describe "filtering", ->
     expect(bestMatch(['Uninstall', 'dir' + path.sep + 'Install'], 'install')).toBe 'dir' + path.sep + 'Install'
 
   it "weighs substring higher than individual characters", ->
+    candidates = [
+      'Git Plus: Stage Hunk',
+      'Git Plus: Reset Head',
+      'Git Plus: Push',
+      'Git Plus: Show'
+    ]
+    expect(bestMatch(candidates, 'push')).toBe 'Git Plus: Push'
     expect(bestMatch(['a_b_c', 'somethingabc'], 'abc')).toBe 'somethingabc'
 
   describe "when the entries are of differing directory depths", ->

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -43,12 +43,27 @@ exports.basenameScore = (string, query, score) ->
   score
 
 exports.score = (string, query) ->
-  return 1 if string is query
+  return 2 if string is query
 
   # Return a perfect score if the file name itself matches the query.
-  return 1 if queryIsLastPathSegment(string, query)
+  return 2 if queryIsLastPathSegment(string, query)
+
+  bonus = 0
+  substringIndex = string.indexOf(query)
+  substringIndexi = string.toUpperCase().indexOf(query.toUpperCase())
+  if substringIndex > -1
+    if substringIndex == 0 or string[substringIndex - 1] is PathSeparator
+      bonus = 1.9
+    else
+      bonus = 1
+  if substringIndexi > -1
+    if substringIndexi == 0 or string[substringIndexi - 1] is PathSeparator
+      bonus = 1.6
+    else
+      bonus = 0.7
 
   totalCharacterScore = 0
+
   queryLength = query.length
   stringLength = string.length
 
@@ -82,7 +97,7 @@ exports.score = (string, query) ->
     totalCharacterScore += characterScore
 
   queryScore = totalCharacterScore / queryLength
-  ((queryScore * (queryLength / stringLength)) + queryScore) / 2
+  ((queryScore * (queryLength / stringLength)) + queryScore + bonus) / 2
 
 queryIsLastPathSegment = (string, query) ->
   if string[string.length - query.length - 1] is PathSeparator

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -50,17 +50,18 @@ exports.score = (string, query) ->
 
   bonus = 0
   substringIndex = string.indexOf(query)
-  substringIndexi = string.toUpperCase().indexOf(query.toUpperCase())
   if substringIndex > -1
     if substringIndex == 0 or string[substringIndex - 1] is PathSeparator
       bonus = 1.9
     else
       bonus = 1
-  if substringIndexi > -1
-    if substringIndexi == 0 or string[substringIndexi - 1] is PathSeparator
-      bonus = 1.6
-    else
-      bonus = 0.7
+  else
+    substringIndexi = string.toUpperCase().indexOf(query.toUpperCase())
+    if substringIndexi > -1
+      if substringIndexi == 0 or string[substringIndexi - 1] is PathSeparator
+        bonus = 1.6
+      else
+        bonus = 0.7
 
   totalCharacterScore = 0
 


### PR DESCRIPTION
Added a arbitrary substring match bonus to the scorer to improve pertinence.
We need a better scoring for query substring matches.
e.g. in command-palette
![fuzzy](https://cloud.githubusercontent.com/assets/10697451/8392096/24aa7870-1cd6-11e5-8956-129f46e2abbf.jpg)

There is still the issue of highlighting the correct substring though