### PR TITLE
Rewrite scoring algorithm to support run of consecutive character, fix acronyms and add optimal selection of character.

### DIFF
--- a/benchmark/benchmark.coffee
+++ b/benchmark/benchmark.coffee
@@ -1,7 +1,7 @@
 fs = require 'fs'
 path = require 'path'
 
-{filter, match} = require '../lib/fuzzaldrin'
+{filter, match} = require '../src/fuzzaldrin'
 
 lines = fs.readFileSync(path.join(__dirname, 'data.txt'), 'utf8').trim().split('\n')
 
@@ -28,16 +28,22 @@ console.log("Filtering #{lines.length} entries for 'node' took #{Date.now() - st
 console.log("======")
 
 startTime = Date.now()
-results5 = filter(lines, 'nde')
-console.log("Filtering #{lines.length} entries for 'nde' took #{Date.now() - startTime}ms for #{results5.length} results (~98% of results are positive, Fuzzy match, [Worst case scenario])")
-
-startTime = Date.now()
 results6 = filter(lines, 'indx')
 console.log("Filtering #{lines.length} entries for 'indx' took #{Date.now() - startTime}ms for #{results6.length} results (~10% of results are positive, Fuzzy match)")
 
 startTime = Date.now()
 results7 = filter(lines, 'nm')
 console.log("Filtering #{lines.length} entries for 'nm' took #{Date.now() - startTime}ms for #{results7.length} results (~98% of results are positive, Acronym)")
+
+console.log("======")
+
+startTime = Date.now()
+results5 = filter(lines, 'nde')
+console.log("Filtering #{lines.length} entries for 'nde' took #{Date.now() - startTime}ms for #{results5.length} results (~98% of results are positive, Fuzzy match, [Worst case scenario])")
+
+startTime = Date.now()
+results8 = filter(lines, 'nde', {maxInners:5000})
+console.log("Filtering #{lines.length} entries for 'nde' took #{Date.now() - startTime}ms for #{results8.length} results (Worst case mitigation strategy)")
 
 console.log("======")
 

--- a/benchmark/benchmark.coffee
+++ b/benchmark/benchmark.coffee
@@ -89,6 +89,17 @@ console.log("Filtering #{lines.length} entries for 'nodemodules' took #{Date.now
 console.log("======")
 
 startTime = Date.now()
+results = filter(lines, 'ndem', forceAllMatch)
+console.log("Filtering #{lines.length} entries for 'ndem' took #{Date.now() - startTime}ms for #{results.length} results (~98% positive + Fuzzy match, [Worst case but shorter srting])")
+
+startTime = Date.now()
+results = filter(lines, 'ndem', legacy)
+console.log("Filtering #{lines.length} entries for 'ndem' took #{Date.now() - startTime}ms for #{results.length} results (Legacy)")
+
+
+console.log("======")
+
+startTime = Date.now()
 query = 'index'
 prepared = prepQuery(query)
 match(line, query, prepared) for line in lines

--- a/benchmark/benchmark.coffee
+++ b/benchmark/benchmark.coffee
@@ -26,7 +26,7 @@ console.log("Filtering #{lines.length} entries for 'indx' took #{Date.now() - st
 console.log("======")
 
 startTime = Date.now()
-results4 = filter(lines, 'node')
+results4 = filter(lines, 'node', {legacy:true})
 console.log("Filtering #{lines.length} entries for 'node' took #{Date.now() - startTime}ms for #{results4.length} results (~98% of results are positive, Legacy method)")
 
 startTime = Date.now()
@@ -42,10 +42,6 @@ console.log("======")
 startTime = Date.now()
 results5 = filter(lines, 'nodemodules')
 console.log("Filtering #{lines.length} entries for 'nodemodules' took #{Date.now() - startTime}ms for #{results5.length} results (~98% positive + Fuzzy match, [Worst case scenario])")
-
-startTime = Date.now()
-results8 = filter(lines, 'nodemodules', {maxInners:10000})
-console.log("Filtering #{lines.length} entries for 'nodemodules' took #{Date.now() - startTime}ms for #{results8.length} results (Worst case mitigation strategy)")
 
 startTime = Date.now()
 results9 = filter(lines, 'nodemodules', {legacy:true})

--- a/benchmark/benchmark.coffee
+++ b/benchmark/benchmark.coffee
@@ -19,35 +19,37 @@ startTime = Date.now()
 results2 = filter(lines, 'index', {legacy:true})
 console.log("Filtering #{lines.length} entries for 'index' took #{Date.now() - startTime}ms for #{results2.length} results (~10% of results are positive, Legacy method)")
 
+startTime = Date.now()
+results6 = filter(lines, 'indx')
+console.log("Filtering #{lines.length} entries for 'indx' took #{Date.now() - startTime}ms for #{results6.length} results (~10% of results are positive, Fuzzy match)")
+
 console.log("======")
+
+startTime = Date.now()
+results4 = filter(lines, 'node')
+console.log("Filtering #{lines.length} entries for 'node' took #{Date.now() - startTime}ms for #{results4.length} results (~98% of results are positive, Legacy method)")
 
 startTime = Date.now()
 results3 = filter(lines, 'node')
 console.log("Filtering #{lines.length} entries for 'node' took #{Date.now() - startTime}ms for #{results3.length} results (~98% of results are positive, mostly Exact match)")
 
 startTime = Date.now()
-results4 = filter(lines, 'node')
-console.log("Filtering #{lines.length} entries for 'node' took #{Date.now() - startTime}ms for #{results4.length} results (~98% of results are positive, Legacy method)")
-
-console.log("======")
-
-startTime = Date.now()
-results6 = filter(lines, 'indx')
-console.log("Filtering #{lines.length} entries for 'indx' took #{Date.now() - startTime}ms for #{results6.length} results (~10% of results are positive, Fuzzy match)")
-
-startTime = Date.now()
 results7 = filter(lines, 'nm')
-console.log("Filtering #{lines.length} entries for 'nm' took #{Date.now() - startTime}ms for #{results7.length} results (~98% of results are positive, Acronym)")
+console.log("Filtering #{lines.length} entries for 'nm' took #{Date.now() - startTime}ms for #{results7.length} results (~98% of results are positive, Acronym match)")
 
 console.log("======")
 
 startTime = Date.now()
-results5 = filter(lines, 'nde')
-console.log("Filtering #{lines.length} entries for 'nde' took #{Date.now() - startTime}ms for #{results5.length} results (~98% of results are positive, Fuzzy match, [Worst case scenario])")
+results5 = filter(lines, 'nodemodules')
+console.log("Filtering #{lines.length} entries for 'nodemodules' took #{Date.now() - startTime}ms for #{results5.length} results (~98% positive + Fuzzy match, [Worst case scenario])")
 
 startTime = Date.now()
-results8 = filter(lines, 'nde', {maxInners:10000})
-console.log("Filtering #{lines.length} entries for 'nde' took #{Date.now() - startTime}ms for #{results8.length} results (Worst case mitigation strategy)")
+results8 = filter(lines, 'nodemodules', {maxInners:10000})
+console.log("Filtering #{lines.length} entries for 'nodemodules' took #{Date.now() - startTime}ms for #{results8.length} results (Worst case mitigation strategy)")
+
+startTime = Date.now()
+results9 = filter(lines, 'nodemodules', {legacy:true})
+console.log("Filtering #{lines.length} entries for 'nodemodules' took #{Date.now() - startTime}ms for #{results9.length} results (Legacy)")
 
 console.log("======")
 

--- a/benchmark/benchmark.coffee
+++ b/benchmark/benchmark.coffee
@@ -5,6 +5,10 @@ path = require 'path'
 
 lines = fs.readFileSync(path.join(__dirname, 'data.txt'), 'utf8').trim().split('\n')
 
+#warmup + compile
+filter(lines, 'index')
+filter(lines, 'index', {legacy:true})
+
 console.log("======")
 
 startTime = Date.now()

--- a/benchmark/benchmark.coffee
+++ b/benchmark/benchmark.coffee
@@ -9,50 +9,87 @@ lines = fs.readFileSync(path.join(__dirname, 'data.txt'), 'utf8').trim().split('
 filter(lines, 'index')
 filter(lines, 'index', {legacy:true})
 
+forceAllMatch = {maxInners:-1}
+legacy = {legacy:true}
+
+
+
 console.log("======")
 
 startTime = Date.now()
 results = filter(lines, 'index')
 console.log("Filtering #{lines.length} entries for 'index' took #{Date.now() - startTime}ms for #{results.length} results (~10% of results are positive, mix exact & fuzzy)")
 
-startTime = Date.now()
-results2 = filter(lines, 'index', {legacy:true})
-console.log("Filtering #{lines.length} entries for 'index' took #{Date.now() - startTime}ms for #{results2.length} results (~10% of results are positive, Legacy method)")
+if results.length isnt 6168
+  console.error("Results count changed! #{results.length} instead of 6168")
+  process.exit(1)
 
 startTime = Date.now()
-results6 = filter(lines, 'indx')
-console.log("Filtering #{lines.length} entries for 'indx' took #{Date.now() - startTime}ms for #{results6.length} results (~10% of results are positive, Fuzzy match)")
+results = filter(lines, 'index', legacy)
+console.log("Filtering #{lines.length} entries for 'index' took #{Date.now() - startTime}ms for #{results.length} results (~10% of results are positive, Legacy method)")
+
 
 console.log("======")
 
 startTime = Date.now()
-results4 = filter(lines, 'node', {legacy:true})
-console.log("Filtering #{lines.length} entries for 'node' took #{Date.now() - startTime}ms for #{results4.length} results (~98% of results are positive, Legacy method)")
+results = filter(lines, 'indx')
+console.log("Filtering #{lines.length} entries for 'indx' took #{Date.now() - startTime}ms for #{results.length} results (~10% of results are positive, Fuzzy match)")
 
 startTime = Date.now()
-results3 = filter(lines, 'node')
-console.log("Filtering #{lines.length} entries for 'node' took #{Date.now() - startTime}ms for #{results3.length} results (~98% of results are positive, mostly Exact match)")
-
-startTime = Date.now()
-results7 = filter(lines, 'nm')
-console.log("Filtering #{lines.length} entries for 'nm' took #{Date.now() - startTime}ms for #{results7.length} results (~98% of results are positive, Acronym match)")
+results = filter(lines, 'indx', legacy)
+console.log("Filtering #{lines.length} entries for 'indx' took #{Date.now() - startTime}ms for #{results.length} results (~10% of results are positive, Fuzzy match, Legacy)")
 
 console.log("======")
 
 startTime = Date.now()
-results5 = filter(lines, 'nodemodules')
-console.log("Filtering #{lines.length} entries for 'nodemodules' took #{Date.now() - startTime}ms for #{results5.length} results (~98% positive + Fuzzy match, [Worst case scenario])")
+results = filter(lines, 'walkdr')
+console.log("Filtering #{lines.length} entries for 'walkdr' took #{Date.now() - startTime}ms for #{results.length} results (~1% of results are positive, fuzzy)")
 
 startTime = Date.now()
-results9 = filter(lines, 'nodemodules', {legacy:true})
-console.log("Filtering #{lines.length} entries for 'nodemodules' took #{Date.now() - startTime}ms for #{results9.length} results (Legacy)")
+results = filter(lines, 'walkdr', legacy)
+console.log("Filtering #{lines.length} entries for 'walkdr' took #{Date.now() - startTime}ms for #{results.length} results (~1% of results are positive, Legacy method)")
+
+
+console.log("======")
+
+startTime = Date.now()
+results = filter(lines, 'node', forceAllMatch)
+console.log("Filtering #{lines.length} entries for 'node' took #{Date.now() - startTime}ms for #{results.length} results (~98% of results are positive, mostly Exact match)")
+
+startTime = Date.now()
+results = filter(lines, 'node', legacy)
+console.log("Filtering #{lines.length} entries for 'node' took #{Date.now() - startTime}ms for #{results.length} results (~98% of results are positive, mostly Exact match, Legacy method)")
+
+
+console.log("======")
+
+startTime = Date.now()
+results = filter(lines, 'nm', forceAllMatch)
+console.log("Filtering #{lines.length} entries for 'nm' took #{Date.now() - startTime}ms for #{results.length} results (~98% of results are positive, Acronym match)")
+
+startTime = Date.now()
+results = filter(lines, 'nm', forceAllMatch)
+console.log("Filtering #{lines.length} entries for 'nm' took #{Date.now() - startTime}ms for #{results.length} results (~98% of results are positive, Acronym match, Legacy method)")
+
+
+console.log("======")
+
+startTime = Date.now()
+results = filter(lines, 'nodemodules', forceAllMatch)
+console.log("Filtering #{lines.length} entries for 'nodemodules' took #{Date.now() - startTime}ms for #{results.length} results (~98% positive + Fuzzy match, [Worst case scenario])")
+
+startTime = Date.now()
+results = filter(lines, 'nodemodules')
+console.log("Filtering #{lines.length} entries for 'nodemodules' took #{Date.now() - startTime}ms for #{results.length} results (~98% positive + Fuzzy match, [Mitigation])")
+
+startTime = Date.now()
+results = filter(lines, 'nodemodules', legacy)
+console.log("Filtering #{lines.length} entries for 'nodemodules' took #{Date.now() - startTime}ms for #{results.length} results (Legacy)")
 
 console.log("======")
 
 startTime = Date.now()
 match(line, 'index') for line in lines
-console.log("Matching #{lines.length} entries for 'index' took #{Date.now() - startTime}ms for #{results.length} results")
+console.log("Matching #{results.length} results for 'index' took #{Date.now() - startTime}ms")
 
-if results.length isnt 6168
-  console.error("Results count changed! #{results.length} instead of 6168")
-  process.exit(1)
+

--- a/benchmark/benchmark.coffee
+++ b/benchmark/benchmark.coffee
@@ -10,6 +10,11 @@ results = filter(lines, 'index')
 console.log("Filtering #{lines.length} entries for 'index' took #{Date.now() - startTime}ms for #{results.length} results")
 
 startTime = Date.now()
+results2 = filter(lines, 'index', {legacy:true})
+console.log("Filtering #{lines.length} entries for 'index' took #{Date.now() - startTime}ms for #{results2.length} results (Legacy method)")
+
+
+startTime = Date.now()
 match(line, 'index') for line in lines
 console.log("Matching #{lines.length} entries for 'index' took #{Date.now() - startTime}ms for #{results.length} results")
 

--- a/benchmark/benchmark.coffee
+++ b/benchmark/benchmark.coffee
@@ -42,7 +42,7 @@ results5 = filter(lines, 'nde')
 console.log("Filtering #{lines.length} entries for 'nde' took #{Date.now() - startTime}ms for #{results5.length} results (~98% of results are positive, Fuzzy match, [Worst case scenario])")
 
 startTime = Date.now()
-results8 = filter(lines, 'nde', {maxInners:5000})
+results8 = filter(lines, 'nde', {maxInners:10000})
 console.log("Filtering #{lines.length} entries for 'nde' took #{Date.now() - startTime}ms for #{results8.length} results (Worst case mitigation strategy)")
 
 console.log("======")

--- a/benchmark/benchmark.coffee
+++ b/benchmark/benchmark.coffee
@@ -9,7 +9,7 @@ console.log("======")
 
 startTime = Date.now()
 results = filter(lines, 'index')
-console.log("Filtering #{lines.length} entries for 'index' took #{Date.now() - startTime}ms for #{results.length} results (~10% of results are positive)")
+console.log("Filtering #{lines.length} entries for 'index' took #{Date.now() - startTime}ms for #{results.length} results (~10% of results are positive, mix exact & fuzzy)")
 
 startTime = Date.now()
 results2 = filter(lines, 'index', {legacy:true})
@@ -34,6 +34,10 @@ console.log("Filtering #{lines.length} entries for 'nde' took #{Date.now() - sta
 startTime = Date.now()
 results6 = filter(lines, 'indx')
 console.log("Filtering #{lines.length} entries for 'indx' took #{Date.now() - startTime}ms for #{results6.length} results (~10% of results are positive, Fuzzy match)")
+
+startTime = Date.now()
+results7 = filter(lines, 'nm')
+console.log("Filtering #{lines.length} entries for 'nm' took #{Date.now() - startTime}ms for #{results7.length} results (~98% of results are positive, Acronym)")
 
 console.log("======")
 

--- a/benchmark/benchmark.coffee
+++ b/benchmark/benchmark.coffee
@@ -1,7 +1,7 @@
 fs = require 'fs'
 path = require 'path'
 
-{filter, match} = require '../src/fuzzaldrin'
+{filter, match, prepQuery} = require '../src/fuzzaldrin'
 
 lines = fs.readFileSync(path.join(__dirname, 'data.txt'), 'utf8').trim().split('\n')
 
@@ -89,7 +89,8 @@ console.log("Filtering #{lines.length} entries for 'nodemodules' took #{Date.now
 console.log("======")
 
 startTime = Date.now()
-match(line, 'index') for line in lines
+query = 'index'
+prepared = prepQuery(query)
+match(line, query, prepared) for line in lines
 console.log("Matching #{results.length} results for 'index' took #{Date.now() - startTime}ms")
-
 

--- a/benchmark/benchmark.coffee
+++ b/benchmark/benchmark.coffee
@@ -5,6 +5,8 @@ path = require 'path'
 
 lines = fs.readFileSync(path.join(__dirname, 'data.txt'), 'utf8').trim().split('\n')
 
+console.log("======")
+
 startTime = Date.now()
 results = filter(lines, 'index')
 console.log("Filtering #{lines.length} entries for 'index' took #{Date.now() - startTime}ms for #{results.length} results (~10% of results are positive)")
@@ -28,6 +30,10 @@ console.log("======")
 startTime = Date.now()
 results5 = filter(lines, 'nde')
 console.log("Filtering #{lines.length} entries for 'nde' took #{Date.now() - startTime}ms for #{results5.length} results (~98% of results are positive, Fuzzy match, [Worst case scenario])")
+
+startTime = Date.now()
+results6 = filter(lines, 'indx')
+console.log("Filtering #{lines.length} entries for 'indx' took #{Date.now() - startTime}ms for #{results6.length} results (~10% of results are positive, Fuzzy match)")
 
 console.log("======")
 

--- a/benchmark/benchmark.coffee
+++ b/benchmark/benchmark.coffee
@@ -5,13 +5,13 @@ path = require 'path'
 
 lines = fs.readFileSync(path.join(__dirname, 'data.txt'), 'utf8').trim().split('\n')
 
-#warmup + compile
-filter(lines, 'index')
-filter(lines, 'index', {legacy:true})
-
 forceAllMatch = {maxInners:-1}
 legacy = {legacy:true}
+mitigation = {maxInners:Math.floor(0.2*lines.length)}
 
+#warmup + compile
+filter(lines, 'index', forceAllMatch)
+filter(lines, 'index', legacy)
 
 
 console.log("======")
@@ -79,7 +79,7 @@ results = filter(lines, 'nodemodules', forceAllMatch)
 console.log("Filtering #{lines.length} entries for 'nodemodules' took #{Date.now() - startTime}ms for #{results.length} results (~98% positive + Fuzzy match, [Worst case scenario])")
 
 startTime = Date.now()
-results = filter(lines, 'nodemodules')
+results = filter(lines, 'nodemodules', mitigation)
 console.log("Filtering #{lines.length} entries for 'nodemodules' took #{Date.now() - startTime}ms for #{results.length} results (~98% positive + Fuzzy match, [Mitigation])")
 
 startTime = Date.now()

--- a/benchmark/benchmark.coffee
+++ b/benchmark/benchmark.coffee
@@ -1,18 +1,35 @@
 fs = require 'fs'
 path = require 'path'
 
-{filter, match} = require '../src/fuzzaldrin'
+{filter, match} = require '../lib/fuzzaldrin'
 
 lines = fs.readFileSync(path.join(__dirname, 'data.txt'), 'utf8').trim().split('\n')
 
 startTime = Date.now()
 results = filter(lines, 'index')
-console.log("Filtering #{lines.length} entries for 'index' took #{Date.now() - startTime}ms for #{results.length} results")
+console.log("Filtering #{lines.length} entries for 'index' took #{Date.now() - startTime}ms for #{results.length} results (~10% of results are positive)")
 
 startTime = Date.now()
 results2 = filter(lines, 'index', {legacy:true})
-console.log("Filtering #{lines.length} entries for 'index' took #{Date.now() - startTime}ms for #{results2.length} results (Legacy method)")
+console.log("Filtering #{lines.length} entries for 'index' took #{Date.now() - startTime}ms for #{results2.length} results (~10% of results are positive, Legacy method)")
 
+console.log("======")
+
+startTime = Date.now()
+results3 = filter(lines, 'node')
+console.log("Filtering #{lines.length} entries for 'node' took #{Date.now() - startTime}ms for #{results3.length} results (~98% of results are positive, mostly Exact match)")
+
+startTime = Date.now()
+results4 = filter(lines, 'node')
+console.log("Filtering #{lines.length} entries for 'node' took #{Date.now() - startTime}ms for #{results4.length} results (~98% of results are positive, Legacy method)")
+
+console.log("======")
+
+startTime = Date.now()
+results5 = filter(lines, 'nde')
+console.log("Filtering #{lines.length} entries for 'nde' took #{Date.now() - startTime}ms for #{results5.length} results (~98% of results are positive, Fuzzy match, [Worst case scenario])")
+
+console.log("======")
 
 startTime = Date.now()
 match(line, 'index') for line in lines

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -25,6 +25,10 @@ describe "filtering", ->
     candidates = ['Gruntfile', 'filter', 'bile', null, '', undefined]
     expect(filter(candidates, 'file')).toEqual ['Gruntfile', 'filter']
 
+  it "require all character to be present", ->
+    candidates = ["Application:Hide"]
+    expect(filter(candidates, 'help')).toEqual []
+
   describe "when the maxResults option is set", ->
     it "limits the results to the result size", ->
       candidates = ['Gruntfile', 'filter', 'bile']
@@ -335,11 +339,20 @@ describe "filtering", ->
     it "allow CamelCase to match even outside of acronym prefix", ->
 
       candidates = [
-        'Git Plus: Sacha',
+        'Git Plus: Stash Save',
+        'Git Plus: Add And Commit',
         'Git Plus: Add All',
       ]
-      expect(bestMatch(candidates, 'git aa')).toBe candidates[1]
-      expect(bestMatch(candidates, 'Git AA')).toBe candidates[1]
+
+      result = filter(candidates, 'git AA')
+      expect(result[0]).toBe candidates[2]
+      expect(result[1]).toBe candidates[1]
+      expect(result[2]).toBe candidates[0]
+
+      #result = filter(candidates, 'git aa')
+      #expect(result[0]).toBe candidates[2]
+      #expect(result[1]).toBe candidates[1]
+      #expect(result[2]).toBe candidates[0]
 
 
     it "account for match structure in CamelCase vs Substring matches", ->
@@ -362,10 +375,12 @@ describe "filtering", ->
       expect(bestMatch(candidates, 'git push')).toBe candidates[1]
       expect(bestMatch(candidates, 'psh')).toBe candidates[0]
 
+    # expect(bestMatch(candidates, 'git PSH')).toBe candidates[0]
+    # expect(bestMatch(candidates, 'git psh')).toBe candidates[0]
+    #
     # not yet supported, because we only scan acronym structure on the start of the query (acronym prefix) :(
     # it might be possible to handle uppercase playing with case sensitivity instead of structure.
-    # expect(bestMatch(candidates, 'git psh')).toBe candidates[0]
-    # expect(bestMatch(candidates, 'git PSH')).toBe candidates[0]
+
 
     it "account for case in CamelCase vs Substring matches", ->
 
@@ -541,6 +556,12 @@ describe "filtering", ->
 
       expect(bestMatch(candidates, 'user')).toBe candidates[1]
 
+      candidates = [
+        path.join('lib', 'exportable.rb'),
+        path.join('app', 'models', 'table.rb')
+      ]
+      expect(bestMatch(candidates, 'table')).toBe candidates[1]
+
 
       candidates = [
         path.join('db', 'emails', 'en', 'refund_notification.html'),
@@ -617,12 +638,6 @@ describe "filtering", ->
       ]
       expect(bestMatch(candidates, 'br f')).toBe candidates[1]
 
-      candidates = [
-        rootPath('barfoo', 'foo')
-        rootPath('foo', 'barfoo')
-      ]
-      expect(bestMatch(candidates, 'bar f')).toBe candidates[1]
-
     it "allow basename bonus to handle query with folder", ->
 
       # Without support for optional character, the basename bonus
@@ -647,7 +662,7 @@ describe "filtering", ->
       expect(bestMatch(candidate, path.join("src", "app"))).toBe candidate[1]
 
       candidate = [
-        path.join('javascript', 'template', 'emails-dialogs.handlebars'),
+        path.join('template', 'emails-dialogs.handlebars'),
         path.join('emails', 'handlers.py')
       ]
 

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -123,7 +123,7 @@ describe "filtering", ->
         rootPath('test', 'filter', 'test.js')
         rootPath('filter', 'test', 'filter.js')
       ]
-      #expect(bestMatch(candidates, path.join('test','filt')  )).toBe candidates[1] ?
+      expect(bestMatch(candidates, path.join('test','filt')  )).toBe candidates[1]
       expect(bestMatch(candidates, path.join('test','filt.') )).toBe candidates[1]
 
   describe "when the candidate is all slashes", ->

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -123,6 +123,7 @@ describe "filtering", ->
       expect(bestMatch(candidates, 'table')).toBe candidates[1]
 
   describe "when the entries contains mixed case", ->
+
     it "weighs exact case matches higher", ->
       candidates = ['statusurl', 'StatusUrl']
       expect(bestMatch(candidates, 'Status')).toBe 'StatusUrl'
@@ -132,64 +133,86 @@ describe "filtering", ->
       expect(bestMatch(candidates, 'statusurl')).toBe 'statusurl'
       expect(bestMatch(candidates, 'StatusUrl')).toBe 'StatusUrl'
 
-  it "weighs abbreviation matches after spaces, underscores, and dashes the same", ->
-    expect(bestMatch(['sub-zero', 'sub zero', 'sub_zero'], 'sz')).toBe 'sub-zero'
-    expect(bestMatch(['sub zero', 'sub_zero', 'sub-zero'], 'sz')).toBe 'sub zero'
-    expect(bestMatch(['sub_zero', 'sub-zero', 'sub zero'], 'sz')).toBe 'sub_zero'
-
-  it "weighs matches at the start of the string or base name higher", ->
-    expect(bestMatch(['a_b_c', 'a_b'], 'ab')).toBe 'a_b'
-    expect(bestMatch(['z_a_b', 'a_b'], 'ab')).toBe 'a_b'
-    expect(bestMatch(['a_b_c', 'c_a_b'], 'ab')).toBe 'a_b_c'
-    expect(bestMatch(['Unin-stall', path.join('dir1', 'dir2', 'dir3', 'Installation')],
-      'install')).toBe path.join('dir1', 'dir2', 'dir3', 'Installation')
-    expect(bestMatch(['Uninstall', path.join('dir', 'Install')], 'install')).toBe path.join('dir', 'Install')
-
-  it "weighs CamelCase matches higher", ->
-    candidates = [
-      'FilterFactors.js',
-      'FilterFactors.styl',
-      'FilterFactors.html',
-      'FilterFactorTests.html',
-      'SpecFilterFactors.js'
-    ]
-    expect(bestMatch(candidates, 'FFT')).toBe 'FilterFactorTests.html'
-    expect(bestMatch(candidates, 'fft')).toBe 'FilterFactorTests.html'
-
-  it "account for case in CamelCase vs Substring matches", ->
-
-    candidates = [
-      'CamelCaseClass.js',
-      'cccManager.java'
-    ]
-    expect(bestMatch(candidates, 'CCC')).toBe candidates[0]
-    expect(bestMatch(candidates, 'ccc')).toBe candidates[1]
-
-  it "prefer CamelCase that happens sooner", ->
-
-    candidates = [
-      'anotherCamelCase',
-      'thisCamelCase000',
-    ]
-    expect(bestMatch(candidates, 'CC')).toBe candidates[1]
-
-  it "prefer CamelCase in shorter haystack", ->
-
-    candidates = [
-      'CamelCase0',
-      'CamelCase',
-    ]
-    expect(bestMatch(candidates, 'CC')).toBe candidates[1]
-
-  it "prefer uninterrupted sequence CamelCase", ->
-
-    candidates = [
-      'CamelSkippedCase',
-      'CamelCaseSkipped',
-    ]
-    expect(bestMatch(candidates, 'CC')).toBe candidates[1]
+    it "weighs exact case matches higher even if string is longer", ->
+      candidates = ['Diagnostic', 'diagnostics0000']
+      expect(bestMatch(candidates, 'diag')).toBe candidates[1]
 
 
+    it "weighs abbreviation matches after spaces, underscores, and dashes the same", ->
+      expect(bestMatch(['sub-zero', 'sub zero', 'sub_zero'], 'sz')).toBe 'sub-zero'
+      expect(bestMatch(['sub zero', 'sub_zero', 'sub-zero'], 'sz')).toBe 'sub zero'
+      expect(bestMatch(['sub_zero', 'sub-zero', 'sub zero'], 'sz')).toBe 'sub_zero'
+
+
+    it "weighs abbreviation higher than scattered letter in a smaller word (also not greeddy)", ->
+      candidates = [
+        'application.rb'
+        'application_controller'
+      ]
+      expect(bestMatch(candidates, 'acon')).toBe candidates[1]
+
+    it "weighs matches at the start of the string or base name higher", ->
+      expect(bestMatch(['a_b_c', 'a_b'], 'ab')).toBe 'a_b'
+      expect(bestMatch(['z_a_b', 'a_b'], 'ab')).toBe 'a_b'
+      expect(bestMatch(['a_b_c', 'c_a_b'], 'ab')).toBe 'a_b_c'
+      expect(bestMatch(['Unin-stall', path.join('dir1', 'dir2', 'dir3', 'Installation')],
+        'install')).toBe path.join('dir1', 'dir2', 'dir3', 'Installation')
+      expect(bestMatch(['Uninstall', path.join('dir', 'Install')], 'install')).toBe path.join('dir', 'Install')
+
+    it "weighs CamelCase matches higher", ->
+      candidates = [
+        'FilterFactors.js',
+        'FilterFactors.styl',
+        'FilterFactors.html',
+        'FilterFactorTests.html',
+        'SpecFilterFactors.js'
+      ]
+      expect(bestMatch(candidates, 'FFT')).toBe 'FilterFactorTests.html'
+      expect(bestMatch(candidates, 'fft')).toBe 'FilterFactorTests.html'
+
+    it "weighs CamelCase matches higher than middle of word exact matches, or snake_abbrv", ->
+
+      candidates = [
+        'switch.css',
+        'user_id_to_client',
+        'ImportanceTableCtrl.js'
+      ]
+      expect(bestMatch(candidates, 'itc')).toBe candidates[2]
+      expect(bestMatch(candidates, 'ITC')).toBe candidates[2]
+
+
+    it "account for case in CamelCase vs Substring matches", ->
+
+      candidates = [
+        'CamelCaseClass.js',
+        'cccManager.java00'
+      ]
+      expect(bestMatch(candidates, 'CCC')).toBe candidates[0]
+      expect(bestMatch(candidates, 'ccc')).toBe candidates[1]
+
+    it "prefer CamelCase that happens sooner", ->
+
+      candidates = [
+        'anotherCamelCase',
+        'thisCamelCase000',
+      ]
+      expect(bestMatch(candidates, 'CC')).toBe candidates[1]
+
+    it "prefer CamelCase in shorter haystack", ->
+
+      candidates = [
+        'CamelCase0',
+        'CamelCase',
+      ]
+      expect(bestMatch(candidates, 'CC')).toBe candidates[1]
+
+    it "prefer uninterrupted sequence CamelCase", ->
+
+      candidates = [
+        'CamelSkippedCase',
+        'CamelCaseSkipped',
+      ]
+      expect(bestMatch(candidates, 'CC')).toBe candidates[1]
 
   describe "when the entries are of differing directory depths", ->
     it "places exact matches first, even if they're deeper", ->

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -115,16 +115,30 @@ describe "filtering", ->
     it "prefer single letter start-of-word exact match vs longer query", ->
 
       candidates = [
-        'Timecop:View',
+        'Timecop: View',
         'Markdown Preview: Copy Html'
       ]
       expect(bestMatch(candidates, 'm')).toBe candidates[1]
 
       candidates = [
-        'Welcome:show',
+        'Welcome: Show',
         'Markdown Preview: Toggle Break On Newline'
       ]
       expect(bestMatch(candidates, 'm')).toBe candidates[1]
+
+      candidates = [
+        'TODO',
+        path.join('doc','README')
+      ]
+      expect(bestMatch(candidates, 'd')).toBe candidates[1]
+
+    it "can select a better occurrence that happens latter in string", ->
+
+      candidates = [
+        'Test Espanol',
+        'Portuges'
+      ]
+      expect(bestMatch(candidates, 'es')).toBe candidates[0]
 
 
 
@@ -135,10 +149,7 @@ describe "filtering", ->
 
   describe "when query match in multiple group", ->
 
-    # string limit, separator limit, camelCase limit
-    # reuse the same method as exact match, should that change, insert test here.
-
-    it "it ranks full-word > start-of-word > end-of-word > middle-of-word > scattered letters", ->
+    it "ranks full-word > start-of-word > end-of-word > middle-of-word > scattered letters", ->
 
       candidates = [
         'model-controller'
@@ -155,7 +166,7 @@ describe "filtering", ->
       expect(result[3]).toBe candidates[1]
       expect(result[4]).toBe candidates[0]
 
-    it "it ranks full-word > start-of-word > end-of-word > middle-of-word > scattered letters (VS directory depth)", ->
+    it "ranks full-word > start-of-word > end-of-word > middle-of-word > scattered letters (VS directory depth)", ->
 
       candidates = [
         path.join('model', 'controller'),
@@ -181,7 +192,7 @@ describe "filtering", ->
       ]
       expect(bestMatch(candidates, 'acon')).toBe candidates[1]
 
-    it "prefer larger group of consecutive letter", ->
+    it "prefers larger group of consecutive letter", ->
 
       #Here all group score the same context (full word).
 
@@ -200,7 +211,7 @@ describe "filtering", ->
       expect(result[3]).toBe candidates[1]
       expect(result[4]).toBe candidates[0]
 
-    it "prefer larger group of consecutive letter VS better context", ->
+    it "prefers larger group of consecutive letter VS better context", ->
 
       #Only apply when EVERY lowe quality context group are longer or equal length
 
@@ -218,7 +229,7 @@ describe "filtering", ->
 
       expect(bestMatch(candidates, 'abcdef')).toBe candidates[1]
 
-    it "allow consecutive character in path overcome deeper path", ->
+    it "allows consecutive character in path overcome deeper path", ->
 
       candidates = [
         path.join('controller', 'app.rb')
@@ -247,7 +258,7 @@ describe "filtering", ->
       expect(bestMatch(candidates, 'statusurl')).toBe 'statusurl'
       expect(bestMatch(candidates, 'StatusUrl')).toBe 'StatusUrl'
 
-    it "account for case while selecting an acronym", ->
+    it "accounts for case while selecting an acronym", ->
       candidates = ['statusurl', 'status_url', 'StatusUrl']
       expect(bestMatch(candidates, 'SU')).toBe 'StatusUrl'
       expect(bestMatch(candidates, 'su')).toBe 'status_url'
@@ -289,7 +300,7 @@ describe "filtering", ->
       # Alignment match "t" of factor preventing to score "T" of Test
       expect(bestMatch(candidates, 'FFT')).toBe 'FilterFactorTests.html'
 
-    it "prefer longer acronym to a smaller case sensitive one", ->
+    it "prefers longer acronym to a smaller case sensitive one", ->
 
       candidates = [
         'efficient'
@@ -312,7 +323,7 @@ describe "filtering", ->
       expect(bestMatch(candidates, 'itc')).toBe candidates[1]
       expect(bestMatch(candidates, 'ITC')).toBe candidates[1]
 
-    it "allow to select between snake_case and CamelCase using case of query", ->
+    it "allows to select between snake_case and CamelCase using case of query", ->
 
       candidates = [
         'switch.css',
@@ -323,7 +334,7 @@ describe "filtering", ->
       expect(bestMatch(candidates, 'ITC')).toBe candidates[2]
 
 
-    it "prefer CamelCase that happens sooner", ->
+    it "prefers CamelCase that happens sooner", ->
 
       candidates = [
         'anotherCamelCase',
@@ -334,7 +345,7 @@ describe "filtering", ->
       expect(bestMatch(candidates, 'CC')).toBe candidates[1]
       expect(bestMatch(candidates, 'CCs')).toBe candidates[1]
 
-    it "prefer CamelCase in shorter haystack", ->
+    it "prefers CamelCase in shorter haystack", ->
 
       candidates = [
         'CamelCase0',
@@ -343,7 +354,7 @@ describe "filtering", ->
       expect(bestMatch(candidates, 'CC')).toBe candidates[1]
       expect(bestMatch(candidates, 'CCs')).toBe candidates[1]
 
-    it "allow CamelCase to match across words", ->
+    it "allows CamelCase to match across words", ->
 
       candidates = [
         'Gallas',
@@ -351,7 +362,7 @@ describe "filtering", ->
       ]
       expect(bestMatch(candidates, 'gaa')).toBe candidates[1]
 
-    it "allow CamelCase to match even outside of acronym prefix", ->
+    it "allows CamelCase to match even outside of acronym prefix", ->
 
       candidates = [
         'Git Plus: Stash Save',
@@ -364,13 +375,13 @@ describe "filtering", ->
       expect(result[1]).toBe candidates[1]
       expect(result[2]).toBe candidates[0]
 
-      #result = filter(candidates, 'git aa')
-      #expect(result[0]).toBe candidates[2]
-      #expect(result[1]).toBe candidates[1]
-      #expect(result[2]).toBe candidates[0]
+      result = filter(candidates, 'git aa')
+      expect(result[0]).toBe candidates[2]
+      expect(result[1]).toBe candidates[1]
+      expect(result[2]).toBe candidates[0]
 
 
-    it "account for match structure in CamelCase vs Substring matches", ->
+    it "accounts for match structure in CamelCase vs Substring matches", ->
 
       candidates = [
         'Input: Select All',
@@ -397,7 +408,7 @@ describe "filtering", ->
     # it might be possible to handle uppercase playing with case sensitivity instead of structure.
 
 
-    it "account for case in CamelCase vs Substring matches", ->
+    it "accounts for case in CamelCase vs Substring matches", ->
 
       candidates = [
         'CamelCaseClass.js',
@@ -431,6 +442,65 @@ describe "filtering", ->
       ]
       expect(bestMatch(candidates, 'bar')).toBe candidates[1]
       expect(bestMatch(candidates, 'br')).toBe candidates[1]
+      expect(bestMatch(candidates, 'b')).toBe candidates[1]
+
+      candidates = [
+        path.join('foo', 'bar'),
+        'foobar'
+        'FooBar'
+        'foo_bar'
+        'foo bar'
+      ]
+      expect(bestMatch(candidates, 'bar')).toBe candidates[0]
+      expect(bestMatch(candidates, 'br')).toBe candidates[0]
+      expect(bestMatch(candidates, 'b')).toBe candidates[0]
+
+    it "prefers shorter basename", ->
+
+      # here full path is same size, but basename is smaller
+      candidates = [
+        path.join('test', 'core_'),
+        path.join('test', '_core'),
+        path.join('test_', 'core'),
+      ]
+
+      expect(bestMatch(candidates, 'core')).toBe candidates[2]
+
+    it "allows to select using folder name", ->
+
+      candidates = [
+        path.join('model', 'core', 'spec.rb')
+        path.join('model', 'controller.rb')
+      ]
+
+      expect(bestMatch(candidates, 'model core')).toBe candidates[0]
+      expect(bestMatch(candidates, path.join('model', 'core'))).toBe candidates[0]
+
+    it "weighs basename matches higher than folder name", ->
+
+      candidates = [
+        path.join('model', 'core', 'spec.rb')
+        path.join('spec', 'model', 'core.rb')
+      ]
+
+      expect(bestMatch(candidates, 'model core')).toBe candidates[1]
+      expect(bestMatch(candidates, path.join('model', 'core'))).toBe candidates[1]
+
+    it "allows to select using acronym in path", ->
+
+      candidates = [
+        path.join('app', 'controller', 'admin_controller')
+        path.join('app', 'asset', 'javascript_admin')
+      ]
+
+      expect(bestMatch(candidates, 'acadmin')).toBe candidates[0]
+
+      candidates = [
+        path.join('app', 'controller', 'macabre_controller')
+        path.join('app', 'controller', 'articles_controller')
+      ]
+
+      expect(bestMatch(candidates, 'aca')).toBe candidates[1]
 
     it "weighs exact basename matches higher than acronym in path", ->
 
@@ -442,30 +512,7 @@ describe "filtering", ->
       expect(bestMatch(candidates, 'core')).toBe candidates[1]
       expect(bestMatch(candidates, 'foo')).toBe candidates[0]
 
-    it "weighs exact match in the path higher than scattered match in the filename", ->
-
-      candidates = [
-        path.join('model', 'core', 'spec.rb')
-        path.join('model', 'controller.rb')
-      ]
-
-      expect(bestMatch(candidates, 'model core')).toBe candidates[0]
-      expect(bestMatch(candidates, path.join('model', 'core'))).toBe candidates[0]
-
-
-    it "prefer shorter basename", ->
-
-      # here full path is same size, but basename is smaller
-      candidates = [
-        path.join('test', 'core_'),
-        path.join('test', '_core'),
-        path.join('test_', 'core'),
-      ]
-
-      expect(bestMatch(candidates, 'core')).toBe candidates[2]
-
-
-    it "ignore path separator at the end", ->
+    it "ignores trailing slashes", ->
 
       candidates = [
         rootPath('bar', 'foo')
@@ -475,36 +522,27 @@ describe "filtering", ->
       expect(bestMatch(candidates, 'br')).toBe candidates[1]
 
 
-    it "allow candidate with all slashes without error", ->
+    it "allows candidate to be all slashes", ->
       candidates = [path.sep, path.sep + path.sep + path.sep]
-      expect(filter(candidates, 'bar', maxResults: 1)).toEqual []
+      expect(filter(candidates, 'bar')).toEqual []
 
 
   describe "when the Query contains slashes (queryHasSlashes)", ->
 
-    it "weighs end of path matches higher", ->
+    it "weighs end-of-path matches higher", ->
 
       candidates = [
-        rootPath('test', 'filter', 'test.js')
-        rootPath('filter', 'test', 'filter.js')
+        path.join('project', 'folder', 'folder', 'file')
+        path.join('folder', 'folder', 'project', 'file')
       ]
-      expect(bestMatch(candidates, path.join('test', 'filt'))).toBe candidates[1]
 
-      candidates = [
-        rootPath('project', 'folder', 'folder', 'file')
-        rootPath('folder', 'folder', 'project', 'file')
-      ]
-      expect(bestMatch(candidates, path.join('project', 'file'))).toBe candidates[1]
       expect(bestMatch(candidates, 'project file')).toBe candidates[0]
-
-  # normally there's a preference for start of the string on the full-path match
-  # having a separator in the query shift that preference toward the end.
-  # alternative would be to always have preference for end of path - aka compactness
+      expect(bestMatch(candidates, path.join('project', 'file'))).toBe candidates[1]
 
 
   describe "when the entries are of differing directory depths", ->
 
-    it "prefer shallow path", ->
+    it "prefers shallow path", ->
 
       candidate = [
         path.join('b', 'z', 'file'),
@@ -533,7 +571,7 @@ describe "filtering", ->
       # But we have no report of searching too deep, because of that folder-depth penalty is pretty weak.
 
 
-    it "allow better basename match to overcome slightly deeper directory / longer overall path", ->
+    it "allows better basename match to overcome slightly deeper directory / longer overall path", ->
 
       candidates = [
         path.join('f', '1_a_z')
@@ -616,7 +654,7 @@ describe "filtering", ->
 
   describe "when the query contain optional characters (generalize when the entries contains spaces)", ->
 
-    it "allow to match path using either backward slash, forward slash, space or colon", ->
+    it "allows to match path using either backward slash, forward slash, space or colon", ->
 
       candidate = [
         path.join('foo', 'bar'),
@@ -656,7 +694,7 @@ describe "filtering", ->
       ]
       expect(bestMatch(candidates, 'br f')).toBe candidates[1]
 
-    it "allow basename bonus to handle query with folder", ->
+    it "allows basename bonus to handle query with folder", ->
 
       # Without support for optional character, the basename bonus
       # would not be able to find "model" inside "user.rb" so the bonus would be 0
@@ -670,10 +708,9 @@ describe "filtering", ->
       expect(bestMatch(candidate, "modeluser")).toBe candidate[0]
       expect(bestMatch(candidate, path.join("model", "user"))).toBe candidate[0]
 
-
       candidate = [
-        path.join('images', 'destroy_discard.png'),
-        path.join('ressources', 'src', 'app.coffee')
+        path.join('destroy_discard_pool.png'),
+        path.join('resources', 'src', 'app_controller.coffee')
       ]
 
       expect(bestMatch(candidate, "src app")).toBe candidate[1]
@@ -688,7 +725,7 @@ describe "filtering", ->
       expect(bestMatch(candidate, path.join("email", "handlers"))).toBe candidate[1]
 
 
-      # But when basename is an good match, it is still preferred
+    it "allows to select between full query and basename using path.sep", ->
 
       candidate = [
         path.join('models', 'user.rb'),
@@ -696,6 +733,9 @@ describe "filtering", ->
       ]
 
       expect(bestMatch(candidate, "modeluser")).toBe candidate[1]
+      expect(bestMatch(candidate, "model user")).toBe candidate[1]
+      expect(bestMatch(candidate, path.join("model","user"))).toBe candidate[0]
+
 
 
   #---------------------------------------------------
@@ -706,7 +746,7 @@ describe "filtering", ->
 
   describe "When entry are sentence / Natural language", ->
 
-    it "Prefer consecutive characters at the start of word", ->
+    it "prefers consecutive characters at the start of word", ->
 
       candidates = [
         'Find And Replace: Select All',

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -1,7 +1,12 @@
 path = require 'path'
-{filter} = require '../src/fuzzaldrin'
+{filter,score} = require '../src/fuzzaldrin'
 
-bestMatch = (candidates, query) ->
+bestMatch = (candidates, query, {debug}={}) ->
+
+  if debug?
+    console.log("\n = Against query: #{query} = ")
+    console.log(" #{score(c, query)}: #{c}") for c in candidates
+
   filter(candidates, query, maxResults: 1)[0]
 
 rootPath = (segments...) ->
@@ -15,6 +20,7 @@ rootPath = (segments...) ->
   joinedPath
 
 describe "filtering", ->
+
   it "returns an array of the most accurate results", ->
     candidates = ['Gruntfile', 'filter', 'bile', null, '', undefined]
     expect(filter(candidates, 'file')).toEqual ['Gruntfile', 'filter']
@@ -24,24 +30,368 @@ describe "filtering", ->
       candidates = ['Gruntfile', 'filter', 'bile']
       expect(bestMatch(candidates, 'file')).toBe 'Gruntfile'
 
-  describe "when subject match is not exactly query", ->
-    it "still find the proper candidate", ->
-    candidates = ['Gruntfile xx', 'filter xx', 'bile xx']
-    expect(bestMatch(candidates, 'filex')).toBe candidates[0]
 
-  describe "when query is exact match", ->
+  #---------------------------------------------------
+  #
+  #                  Exact match
+  #
+
+  describe "when query is an exact match", ->
+
     it "prefer match at word boundary (string limit)", ->
-    candidates = ['gruntfilea', 'agruntfile']
-    expect(bestMatch(candidates, 'file')).toBe candidates[1]
-    expect(bestMatch(candidates, 'grunt')).toBe candidates[0]
+      candidates = ['0gruntfile0', 'gruntfile0', '0gruntfile']
+      expect(bestMatch(candidates, 'file')).toBe candidates[2]
+      expect(bestMatch(candidates, 'grunt')).toBe candidates[1]
 
     it "prefer match at word boundary (separator limit)", ->
-    candidates = ['hello gruntfilea world', 'hello agruntfile world']
-    expect(bestMatch(candidates, 'file')).toBe candidates[1]
-    expect(bestMatch(candidates, 'grunt')).toBe candidates[0]
+      candidates = ['0gruntfile0', 'hello gruntfile0', '0gruntfile world']
+      expect(bestMatch(candidates, 'file')).toBe candidates[2]
+      expect(bestMatch(candidates, 'grunt')).toBe candidates[1]
+
+    it "prefer match at word boundary (camelCase limit)", ->
+      candidates = ['0gruntfile0', 'helloGruntfile0', '0gruntfileWorld']
+      expect(bestMatch(candidates, 'file')).toBe candidates[2]
+      expect(bestMatch(candidates, 'grunt')).toBe candidates[1]
+
+
+    it "it ranks full-word > start-of-word > end-of-word > middle-of-word > split > scattered letters", ->
+
+      candidates = [
+        'controller',
+        '0 co re 00',
+        '0core0 000',
+        '0core 0000',
+        '0 core0 00',
+        '0 core 000'
+      ]
+
+      result = filter(candidates, 'core')
+      expect(result[0]).toBe candidates[5]
+      expect(result[1]).toBe candidates[4]
+      expect(result[2]).toBe candidates[3]
+      expect(result[3]).toBe candidates[2]
+      expect(result[4]).toBe candidates[1]
+      expect(result[5]).toBe candidates[0]
+
+    it "rank middle of word case-insensitive match better than complete word not quite exact match (sequence length is king)", ->
+
+      candidates = [
+        'ZFILEZ',
+        'fil e'
+      ]
+
+      expect(bestMatch(candidates, 'file')).toBe candidates[0]
+
+    it "prefer smaller haystack", ->
+
+      candidates = [
+        'core_',
+        'core'
+      ]
+
+      expect(bestMatch(candidates, 'core')).toBe candidates[1]
+
+
+    it "prefer match at the start of the string", ->
+
+      candidates = [
+        'data_core',
+        'core_data'
+      ]
+
+      expect(bestMatch(candidates, 'core')).toBe candidates[1]
+
+      candidates = [
+        'hello_data_core',
+        'hello_core_data'
+      ]
+
+      expect(bestMatch(candidates, 'core')).toBe candidates[1]
+
+
+  #---------------------------------------------------
+  #
+  #                  Consecutive letters
+  #
+
+  describe "when query match in multiple group", ->
+
+    # string limit, separator limit, camelCase limit
+    # reuse the same method as exact match, should that change, insert test here.
+
+    it "it ranks full-word > start-of-word > end-of-word > middle-of-word > scattered letters", ->
+
+      candidates = [
+        'model-controller'
+        'model-0core0-000'
+        'model-0core-0000'
+        'model-0-core0-00'
+        'model-0-core-000'
+      ]
+
+      result = filter(candidates, 'modelcore')
+      expect(result[0]).toBe candidates[4]
+      expect(result[1]).toBe candidates[3]
+      expect(result[2]).toBe candidates[2]
+      expect(result[3]).toBe candidates[1]
+      expect(result[4]).toBe candidates[0]
+
+    it "it ranks full-word > start-of-word > end-of-word > middle-of-word > scattered letters (VS directory depth)", ->
+
+      candidates = [
+        path.join('model', 'controller'),
+        path.join('0', 'model', '0core0_0'),
+        path.join('0', '0', 'model', '0core_00'),
+        path.join('0', '0', '0', 'model', 'core0_00'),
+        path.join('0', '0', '0', '0', 'model', 'core_000')
+      ]
+
+      result = filter(candidates, 'model core')
+      expect(result[0]).toBe candidates[4]
+      expect(result[1]).toBe candidates[3]
+      expect(result[2]).toBe candidates[2]
+      expect(result[3]).toBe candidates[1]
+      expect(result[4]).toBe candidates[0]
+
+
+    it "weighs consecutive character higher than scattered letters", ->
+
+      candidates = [
+        'application.rb'
+        'application_controller'
+      ]
+      expect(bestMatch(candidates, 'acon')).toBe candidates[1]
+
+    it "prefer larger group of consecutive letter", ->
+
+      #Here all group score the same context (full word).
+
+      candidates = [
+        'ab cd ef',
+        ' abc def',
+        ' abcd ef',
+        ' abcde f',
+        '  abcdef'
+      ]
+
+      result = filter(candidates, 'abcdef')
+      expect(result[0]).toBe candidates[4]
+      expect(result[1]).toBe candidates[3]
+      expect(result[2]).toBe candidates[2]
+      expect(result[3]).toBe candidates[1]
+      expect(result[4]).toBe candidates[0]
+
+    it "prefer larger group of consecutive letter VS better context", ->
+
+      #Only apply when EVERY lowe quality context group are longer or equal length
+
+      candidates = [
+        'ab cd ef', # 3 x 2
+        '0abc0def0' # 2 x 3
+      ]
+
+      expect(bestMatch(candidates, 'abcdef')).toBe candidates[1]
+
+      candidates = [
+        'ab cd ef', # 2 x 2 + 2
+        '0abcd0ef0' # 1 x 4 + 2
+      ]
+
+      expect(bestMatch(candidates, 'abcdef')).toBe candidates[1]
+
+    it "allow consecutive character in path overcome deeper path", ->
+
+      candidates = [
+        path.join('controller', 'app.rb')
+        path.join('controller', 'core', 'app.rb')
+      ]
+      expect(bestMatch(candidates, 'core app')).toBe candidates[1]
+
+    it "weighs matches at the start of the string or base name higher", ->
+
+      expect(bestMatch(['a_b_c', 'a_b'], 'ab')).toBe 'a_b'
+      expect(bestMatch(['z_a_b', 'a_b'], 'ab')).toBe 'a_b'
+      expect(bestMatch(['a_b_c', 'c_a_b'], 'ab')).toBe 'a_b_c'
+
+
+  #---------------------------------------------------
+  #
+  #                  Acronym + Case Sensitivity
+  #
+
+  describe "when the entries contains mixed case", ->
+
+    it "weighs exact case matches higher", ->
+      candidates = ['statusurl', 'StatusUrl']
+      expect(bestMatch(candidates, 'Status')).toBe 'StatusUrl'
+      expect(bestMatch(candidates, 'status')).toBe 'statusurl'
+      expect(bestMatch(candidates, 'statusurl')).toBe 'statusurl'
+      expect(bestMatch(candidates, 'StatusUrl')).toBe 'StatusUrl'
+
+    it "account for case while selecting an acronym", ->
+      candidates = ['statusurl', 'status_url', 'StatusUrl']
+      expect(bestMatch(candidates, 'SU')).toBe 'StatusUrl'
+      expect(bestMatch(candidates, 'su')).toBe 'status_url'
+      expect(bestMatch(candidates, 'st')).toBe 'statusurl'
+
+    it "weighs exact case matches higher", ->
+
+      candidates = ['Diagnostic', 'diagnostics0000']
+      expect(bestMatch(candidates, 'diag')).toBe candidates[1]
+      expect(bestMatch(candidates, 'diago')).toBe candidates[1]
+
+      candidates = ['download_thread', 'DownloadTask']
+      expect(bestMatch(candidates, 'down')).toBe candidates[0]
+      expect(bestMatch(candidates, 'downt')).toBe candidates[0]
+      expect(bestMatch(candidates, 'downta')).toBe candidates[1]
+      expect(bestMatch(candidates, 'dt')).toBe candidates[0]
+      expect(bestMatch(candidates, 'DT')).toBe candidates[1]
+
+    it "weighs case sentitive matches higher Vs directory depth", ->
+
+      candidates = [path.join('0', 'Diagnostic'), path.join('0', '0', '0', 'diagnostics00')]
+      expect(bestMatch(candidates, 'diag')).toBe candidates[1]
+      expect(bestMatch(candidates, 'diago')).toBe candidates[1]
+
+
+    it "weighs abbreviation matches after spaces, underscores, and dashes the same", ->
+      expect(bestMatch(['sub-zero', 'sub zero', 'sub_zero'], 'sz')).toBe 'sub-zero'
+      expect(bestMatch(['sub zero', 'sub_zero', 'sub-zero'], 'sz')).toBe 'sub zero'
+      expect(bestMatch(['sub_zero', 'sub-zero', 'sub zero'], 'sz')).toBe 'sub_zero'
+
+
+    it "weighs CamelCase matches higher", ->
+
+      candidates = [
+        'FilterFactors.html',
+        'FilterFactorTests.html'
+      ]
+
+      # Alignment match "t" of factor preventing to score "T" of Test
+      expect(bestMatch(candidates, 'FFT')).toBe 'FilterFactorTests.html'
+
+    it "prefer longer acronym to a smaller case sensitive one", ->
+
+      candidates = [
+        'efficient'
+        'fun fact'
+        'FileFactory'
+        'FilterFactorTests.html'
+      ]
+
+      # fun fact is case-sensitive match for fft, but the t of fact is not an acronym
+      expect(bestMatch(candidates, 'fft')).toBe 'FilterFactorTests.html'
+      expect(bestMatch(candidates, 'ff')).toBe 'fun fact'
+      expect(bestMatch(candidates, 'FF')).toBe 'FileFactory'
+
+    it "weighs acronym matches higher than middle of word exact match", ->
+
+      candidates = [
+        'switch.css',
+        'ImportanceTableCtrl.js'
+      ]
+      expect(bestMatch(candidates, 'itc')).toBe candidates[1]
+      expect(bestMatch(candidates, 'ITC')).toBe candidates[1]
+
+    it "allow to select between snake_case and CamelCase using case of query", ->
+
+      candidates = [
+        'switch.css',
+        'user_id_to_client',
+        'ImportanceTableCtrl.js'
+      ]
+      expect(bestMatch(candidates, 'itc')).toBe candidates[1]
+      expect(bestMatch(candidates, 'ITC')).toBe candidates[2]
+
+
+    it "prefer CamelCase that happens sooner", ->
+
+      candidates = [
+        'anotherCamelCase',
+        'thisCamelCase000',
+      ]
+
+      #We test once for exact acronym then for general purpose match.
+      expect(bestMatch(candidates, 'CC')).toBe candidates[1]
+      expect(bestMatch(candidates, 'CCs')).toBe candidates[1]
+
+    it "prefer CamelCase in shorter haystack", ->
+
+      candidates = [
+        'CamelCase0',
+        'CamelCase',
+      ]
+      expect(bestMatch(candidates, 'CC')).toBe candidates[1]
+      expect(bestMatch(candidates, 'CCs')).toBe candidates[1]
+
+    it "allow CamelCase to match across words", ->
+
+      candidates = [
+        'Gallas',
+        'Git Plus: Add All', #skip the Plus, still get bonus.
+      ]
+      expect(bestMatch(candidates, 'gaa')).toBe candidates[1]
+
+    it "allow CamelCase to match even outside of acronym prefix", ->
+
+      candidates = [
+        'Git Plus: Sacha',
+        'Git Plus: Add All',
+      ]
+      expect(bestMatch(candidates, 'git aa')).toBe candidates[1]
+      expect(bestMatch(candidates, 'Git AA')).toBe candidates[1]
+
+
+    it "account for match structure in CamelCase vs Substring matches", ->
+
+      candidates = [
+        'Input: Select All',
+        'Application: Install'
+      ]
+
+      expect(bestMatch(candidates, 'install')).toBe candidates[1]
+      expect(bestMatch(candidates, 'isa')).toBe candidates[0]
+      expect(bestMatch(candidates, 'isall')).toBe candidates[0]
+
+      candidates = [
+        'Git Plus: Stage Hunk',
+        'Git Plus: Push'
+      ]
+
+      expect(bestMatch(candidates, 'push')).toBe candidates[1]
+      expect(bestMatch(candidates, 'git push')).toBe candidates[1]
+      expect(bestMatch(candidates, 'psh')).toBe candidates[0]
+
+    # not yet supported, because we only scan acronym structure on the start of the query (acronym prefix) :(
+    # it might be possible to handle uppercase playing with case sensitivity instead of structure.
+    # expect(bestMatch(candidates, 'git psh')).toBe candidates[0]
+    # expect(bestMatch(candidates, 'git PSH')).toBe candidates[0]
+
+    it "account for case in CamelCase vs Substring matches", ->
+
+      candidates = [
+        'CamelCaseClass.js',
+        'cccManagerUI.java'
+      ]
+
+      #We test once for exact acronym
+      expect(bestMatch(candidates, 'CCC')).toBe candidates[0]
+      expect(bestMatch(candidates, 'ccc')).toBe candidates[1]
+
+      #then for general purpose match.
+      expect(bestMatch(candidates, 'CCCa')).toBe candidates[0]
+      expect(bestMatch(candidates, 'ccca')).toBe candidates[1]
+
+
+  #---------------------------------------------------
+  #
+  #                 Path / Fuzzy finder
+  #
 
   describe "when the entries contains slashes", ->
+
     it "weighs basename matches higher", ->
+
       candidates = [
         rootPath('bar', 'foo')
         rootPath('foo', 'bar')
@@ -49,6 +399,40 @@ describe "filtering", ->
       expect(bestMatch(candidates, 'bar')).toBe candidates[1]
       expect(bestMatch(candidates, 'br')).toBe candidates[1]
 
+    it "weighs exact basename matches higher than acronym in path", ->
+
+      candidates = [
+        path.join('c', 'o', 'r', 'e', 'foobar')
+        path.join('f', 'o', 'o', 'b', 'a', 'r', 'core')
+      ]
+
+      expect(bestMatch(candidates, 'core')).toBe candidates[1]
+      expect(bestMatch(candidates, 'foo')).toBe candidates[0]
+
+    it "weighs exact match in the path higher than scattered match in the filename", ->
+
+      candidates = [
+        path.join('model', 'core', 'spec.rb')
+        path.join('model', 'controller.rb')
+      ]
+
+      expect(bestMatch(candidates, 'model core')).toBe candidates[0]
+      expect(bestMatch(candidates, path.join('model', 'core'))).toBe candidates[0]
+
+
+    it "prefer shorter basename", ->
+
+      # here full path is same size, but basename is smaller
+      candidates = [
+        path.join('test', 'core_'),
+        path.join('test', '_core'),
+        path.join('test_', 'core'),
+      ]
+
+      expect(bestMatch(candidates, 'core')).toBe candidates[2]
+
+
+    it "ignore path separator at the end", ->
 
       candidates = [
         rootPath('bar', 'foo')
@@ -58,28 +442,34 @@ describe "filtering", ->
       expect(bestMatch(candidates, 'br')).toBe candidates[1]
 
 
-      candidates = [
-        rootPath('bar', 'foo')
-        rootPath('foo', 'bar')
-        'bar'
-      ]
-      expect(bestMatch(candidates, 'bar')).toEqual candidates[2]
+    it "allow candidate with all slashes without error", ->
+      candidates = [path.sep, path.sep + path.sep + path.sep]
+      expect(filter(candidates, 'bar', maxResults: 1)).toEqual []
+
+
+  describe "when the Query contains slashes (queryHasSlashes)", ->
+
+    it "weighs end of path matches higher", ->
 
       candidates = [
-        rootPath('bar', 'foo')
-        rootPath('foo', 'bar')
-        rootPath('bar')
+        rootPath('test', 'filter', 'test.js')
+        rootPath('filter', 'test', 'filter.js')
       ]
-      expect(bestMatch(candidates, 'bar')).toBe candidates[2]
+      expect(bestMatch(candidates, path.join('test', 'filt'))).toBe candidates[1]
 
       candidates = [
-        rootPath('bar', 'foo')
-        "bar#{path.sep}#{path.sep}#{path.sep}#{path.sep}#{path.sep}#{path.sep}"
+        rootPath('project', 'folder', 'folder', 'file')
+        rootPath('folder', 'folder', 'project', 'file')
       ]
-      expect(bestMatch(candidates, 'bar')).toBe candidates[1]
+      expect(bestMatch(candidates, path.join('project', 'file'))).toBe candidates[1]
+      expect(bestMatch(candidates, 'project file')).toBe candidates[0]
 
-      expect(bestMatch([path.join('f', 'o', '1_a_z'), path.join('f', 'o', 'a_z')], 'az')).toBe path.join('f','o','a_z')
-      expect(bestMatch([path.join('f', '1_a_z'), path.join('f', 'o', 'a_z')], 'az')).toBe path.join('f', 'o', 'a_z')
+  # normally there's a preference for start of the string on the full-path match
+  # having a separator in the query shift that preference toward the end.
+  # alternative would be to always have preference for end of path - aka compactness
+
+
+  describe "when the entries are of differing directory depths", ->
 
     it "prefer shallow path", ->
 
@@ -99,33 +489,96 @@ describe "filtering", ->
       expect(bestMatch(candidate, "file")).toBe candidate[1]
       expect(bestMatch(candidate, "fle")).toBe candidate[1]
 
-    it "allow to match in folder path", ->
       candidate = [
-        path.join('base', 'file'),
-        path.join('bar', 'file')
+        path.join('A Long User Full-Name', 'My Documents', 'file'),
+        path.join('bin', 'lib', 'src', 'test', 'spec', 'file')
       ]
 
-      expect(bestMatch(candidate, "base file")).toBe candidate[0]
-      expect(bestMatch(candidate, "as fle")).toBe candidate[0]
+      expect(bestMatch(candidate, "file")).toBe candidate[0]
 
-    it "prefer full path almost exact match, to match in file only", ->
+      # We have plenty of report on how this or that should win because file is a better basename match
+      # But we have no report of searching too deep, because of that folder-depth penalty is pretty weak.
 
-      candidate = [
-        path.join('models', 'user.b'),
-        path.join('migrate', 'moderator_column_users.rb')
+
+    it "allow better basename match to overcome slightly deeper directory / longer overall path", ->
+
+      candidates = [
+        path.join('f', '1_a_z')
+        path.join('f', 'o', 'a_z')
       ]
 
-      expect(bestMatch(candidate, "modeluser")).toBe candidate[0]
-      expect(bestMatch(candidate, "migrateuser")).toBe candidate[1]
+      expect(bestMatch(candidates, 'az')).toBe candidates[1]
 
-      candidate = [
-        path.join('models', 'user.b'),
-        path.join('migrate', 'model_users.rb')
+      candidates = [
+        path.join('app', 'models', 'automotive', 'car.rb')
+        path.join('spec', 'carts.rb')
       ]
 
-      expect(bestMatch(candidate, "modeluser")).toBe candidate[1]
+      expect(bestMatch(candidates, 'car.rb')).toBe candidates[0]
 
-    it "allow to match using wrong slash, space or colon", ->
+      candidates = [
+        path.join('application', 'applicationPageStateServiceSpec.js')
+        path.join('view', 'components', 'actions', 'actionsServiceSpec.js')
+      ]
+
+      expect(bestMatch(candidates, 'actionsServiceSpec.js')).toBe candidates[1]
+      expect(bestMatch(candidates, 'ss')).toBe candidates[1]
+
+
+      candidates = [
+        path.join('spec', 'models', 'user_search_spec.rb')
+        path.join('spec', 'models', 'listing', 'location_detection', 'usa_spec.rb')
+      ]
+
+      expect(bestMatch(candidates, 'usa_spec')).toBe candidates[1]
+      expect(bestMatch(candidates, 'usa spec')).toBe candidates[1]
+      expect(bestMatch(candidates, 'usa')).toBe candidates[1]
+
+      candidates = [
+        path.join('spec', 'models', 'usa_spec.rb')
+        path.join('spec', 'models', 'listing', 'location_detection', 'user_search_spec.rb')
+      ]
+
+      expect(bestMatch(candidates, 'user')).toBe candidates[1]
+
+
+      candidates = [
+        path.join('db', 'emails', 'en', 'refund_notification.html'),
+        path.join('app', 'views', 'admin', 'home', 'notification.erb')
+      ]
+
+      expect(bestMatch(candidates, 'notification')).toBe candidates[1]
+
+      candidates = [
+        path.join('db', 'emails', 'en', 'refund_notification.html'),
+        path.join('app', 'views', 'admin', 'home', '_notification_admin.erb')
+      ]
+
+      expect(bestMatch(candidates, '_notification')).toBe candidates[1]
+
+      candidates = [
+        path.join('javascript', 'video-package', 'video-backbone.js'),
+        path.join('third_party', 'javascript', 'project-src', 'backbone', 'backbone.js')
+      ]
+
+      expect(bestMatch(candidates, 'backbone')).toBe candidates[1]
+
+      candidates = [
+        path.join('spec', 'controllers', 'apps_controller_spec.rb'),
+        path.join('app', 'controllers', 'api_v2_featured', 'apps_controller.rb')
+      ]
+
+      expect(bestMatch(candidates, 'apps_controller')).toBe candidates[1]
+
+
+  #
+  #  Optional Characters
+  #
+
+  describe "when the query contain optional characters (generalize when the entries contains spaces)", ->
+
+    it "allow to match path using either backward slash, forward slash, space or colon", ->
+
       candidate = [
         path.join('foo', 'bar'),
         path.join('model', 'user'),
@@ -136,31 +589,28 @@ describe "filtering", ->
       expect(bestMatch(candidate, "model\\user")).toBe candidate[1]
       expect(bestMatch(candidate, "model::user")).toBe candidate[1]
 
+    it "prefer matches where the optional character is present", ->
 
-
-  describe "when the query contains slashes", ->
-    it "weighs basename matches higher", ->
-      candidates = [
-        rootPath('test', 'filter', 'test.js')
-        rootPath('filter', 'test', 'filter.js')
+      candidate = [
+        'ModelUser',
+        'model user',
+        'model/user',
+        'model\\user',
+        'model::user',
+        'model_user',
+        'model-user',
       ]
-      expect(bestMatch(candidates, path.join('test','filt')  )).toBe candidates[1]
-      expect(bestMatch(candidates, path.join('test','filt.') )).toBe candidates[1]
 
-  describe "when the candidate is all slashes", ->
-    it "does not throw an exception", ->
-      candidates = [path.sep]
-      expect(filter(candidates, 'bar', maxResults: 1)).toEqual []
+      expect(bestMatch(candidate, "mdl user")).toBe candidate[1]
+      expect(bestMatch(candidate, "mdl/user")).toBe candidate[2]
+      expect(bestMatch(candidate, "mdl\\user")).toBe candidate[3]
+      expect(bestMatch(candidate, "mdl::user")).toBe candidate[4]
+      expect(bestMatch(candidate, "mdl_user")).toBe candidate[5]
+      expect(bestMatch(candidate, "mdl-user")).toBe candidate[6]
 
-  describe "when the entries contains spaces", ->
-    it "treats spaces as slashes", ->
-      candidates = [
-        rootPath('bar', 'foo')
-        rootPath('foo', 'bar')
-      ]
-      expect(bestMatch(candidates, 'br f')).toBe candidates[0]
 
-    it "weighs basename matches higher", ->
+    it "weighs basename matches higher (space don't have a strict preference for slash)", ->
+
       candidates = [
         rootPath('bar', 'foo')
         rootPath('foo', 'bar foo')
@@ -171,156 +621,60 @@ describe "filtering", ->
         rootPath('barfoo', 'foo')
         rootPath('foo', 'barfoo')
       ]
-      expect(bestMatch(candidates, 'br f')).toBe candidates[1]
+      expect(bestMatch(candidates, 'bar f')).toBe candidates[1]
 
-      candidates = [
-        path.join('lib', 'exportable.rb')
-        path.join('app', 'models', 'table.rb')
+    it "allow basename bonus to handle query with folder", ->
+
+      # Without support for optional character, the basename bonus
+      # would not be able to find "model" inside "user.rb" so the bonus would be 0
+
+      candidate = [
+        path.join('www', 'lib', 'models', 'user.rb'),
+        path.join('migrate', 'moderator_column_users.rb')
       ]
-      expect(bestMatch(candidates, 'table')).toBe candidates[1]
-      expect(bestMatch(candidates, 'tble')).toBe candidates[1]
+
+      expect(bestMatch(candidate, "model user")).toBe candidate[0]
+      expect(bestMatch(candidate, "modeluser")).toBe candidate[0]
+      expect(bestMatch(candidate, path.join("model", "user"))).toBe candidate[0]
 
 
-  describe "when the entries contains mixed case", ->
-
-    it "weighs exact case matches higher", ->
-      candidates = ['statusurl', 'StatusUrl']
-      expect(bestMatch(candidates, 'Status')).toBe 'StatusUrl'
-      expect(bestMatch(candidates, 'status')).toBe 'statusurl'
-      expect(bestMatch(candidates, 'statusurl')).toBe 'statusurl'
-      expect(bestMatch(candidates, 'StatusUrl')).toBe 'StatusUrl'
-
-    it "account for case while selecting an acronym", ->
-      candidates = ['statusurl', 'status_url', 'StatusUrl']
-      expect(bestMatch(candidates, 'SU')).toBe 'StatusUrl'
-      expect(bestMatch(candidates, 'su')).toBe 'status_url'
-      expect(bestMatch(candidates, 'st')).toBe 'statusurl'
-
-    it "weighs exact case matches higher even if string is longer", ->
-      candidates = ['Diagnostic', 'diagnostics0000']
-      expect(bestMatch(candidates, 'diag')).toBe candidates[1]
-      expect(bestMatch(candidates, 'diags')).toBe candidates[1]
-
-    it "weighs abbreviation matches after spaces, underscores, and dashes the same", ->
-      expect(bestMatch(['sub-zero', 'sub zero', 'sub_zero'], 'sz')).toBe 'sub-zero'
-      expect(bestMatch(['sub zero', 'sub_zero', 'sub-zero'], 'sz')).toBe 'sub zero'
-      expect(bestMatch(['sub_zero', 'sub-zero', 'sub zero'], 'sz')).toBe 'sub_zero'
-
-    it "weighs abbreviation higher than scattered letter in a smaller word (also not greeddy)", ->
-      candidates = [
-        'application.rb'
-        'application_controller'
+      candidate = [
+        path.join('images', 'destroy_discard.png'),
+        path.join('ressources', 'src', 'app.coffee')
       ]
-      expect(bestMatch(candidates, 'acon')).toBe candidates[1]
 
-    it "weighs matches at the start of the string or base name higher", ->
-      expect(bestMatch(['a_b_c', 'a_b'], 'ab')).toBe 'a_b'
-      expect(bestMatch(['z_a_b', 'a_b'], 'ab')).toBe 'a_b'
-      expect(bestMatch(['a_b_c', 'c_a_b'], 'ab')).toBe 'a_b_c'
-      expect(bestMatch(['Unin-stall', path.join('dir1', 'dir2', 'dir3', 'Installation')],
-        'install')).toBe path.join('dir1', 'dir2', 'dir3', 'Installation')
-      expect(bestMatch(['Uninstall', path.join('dir', 'Install')], 'install')).toBe path.join('dir', 'Install')
+      expect(bestMatch(candidate, "src app")).toBe candidate[1]
+      expect(bestMatch(candidate, path.join("src", "app"))).toBe candidate[1]
 
-    it "weighs CamelCase matches higher", ->
-      candidates = [
-        'FilterFactors.js',
-        'FilterFactors.styl',
-        'FilterFactors.html',
-        'FilterFactorTests.html',
-        'SpecFilterFactors.js'
+      candidate = [
+        path.join('javascript', 'template', 'emails-dialogs.handlebars'),
+        path.join('emails', 'handlers.py')
       ]
-      expect(bestMatch(candidates, 'FFT')).toBe 'FilterFactorTests.html'
-      expect(bestMatch(candidates, 'fft')).toBe 'FilterFactorTests.html'
-      expect(bestMatch(candidates, 'fft.html')).toBe 'FilterFactorTests.html'
+
+      expect(bestMatch(candidate, "email handlers")).toBe candidate[1]
+      expect(bestMatch(candidate, path.join("email", "handlers"))).toBe candidate[1]
 
 
-    it "weighs Abbreviation matches higher than middle of word", ->
+      # But when basename is an good match, it is still preferred
 
-      candidates = [
-        'switch.css',
-        'userid_to_client',
-        'ImportanceTableCtrl.js'
+      candidate = [
+        path.join('models', 'user.rb'),
+        path.join('migrate', 'model_users.rb')
       ]
-      expect(bestMatch(candidates, 'itc')).toBe candidates[2]
-      expect(bestMatch(candidates, 'ITC')).toBe candidates[2]
+
+      expect(bestMatch(candidate, "modeluser")).toBe candidate[1]
 
 
-    it "account for case in CamelCase vs Substring matches", ->
-
-      candidates = [
-        'CamelCaseClass.js',
-        'cccManager.java00'
-      ]
-      expect(bestMatch(candidates, 'CCC')).toBe candidates[0]
-      expect(bestMatch(candidates, 'ccc')).toBe candidates[1]
-
-    it "prefer CamelCase that happens sooner", ->
-
-      candidates = [
-        'anotherCamelCase',
-        'thisCamelCase000',
-      ]
-      expect(bestMatch(candidates, 'CC')).toBe candidates[1]
-      expect(bestMatch(candidates, 'CCa')).toBe candidates[1]
-      expect(bestMatch(candidates, 'CCe')).toBe candidates[1]
+  #---------------------------------------------------
+  #
+  #                 Command Palette
+  #
 
 
-    it "prefer CamelCase in shorter haystack", ->
+  describe "When entry are sentence / Natural language", ->
 
-      candidates = [
-        'CamelCase0',
-        'CamelCase',
-      ]
-      expect(bestMatch(candidates, 'CC')).toBe candidates[1]
-      expect(bestMatch(candidates, 'CCa')).toBe candidates[1]
-      expect(bestMatch(candidates, 'CCe')).toBe candidates[1]
+    it "Prefer consecutive characters at the start of word", ->
 
-    it "prefer uninterrupted sequence CamelCase", ->
-
-      candidates = [
-        'CamelSkippedCase',
-        'CamelCaseSkipped',
-      ]
-      expect(bestMatch(candidates, 'CC')).toBe candidates[1]
-      expect(bestMatch(candidates, 'CCa')).toBe candidates[1]
-      expect(bestMatch(candidates, 'CCe')).toBe candidates[1]
-
-
-  describe "when the entries are of differing directory depths", ->
-    it "places exact matches first, even if they're deeper", ->
-      candidates = [
-        path.join('app', 'models', 'automotive', 'car.rb')
-        path.join('spec', 'factories', 'cars.rb')
-      ]
-      expect(bestMatch(candidates, 'car.rb')).toBe candidates[0]
-
-      candidates = [
-        path.join('app', 'models', 'automotive', 'car.rb')
-        'car.rb'
-      ]
-      expect(bestMatch(candidates, 'car.rb')).toBe candidates[1]
-
-      candidates = [
-        'car.rb',
-        path.join('app', 'models', 'automotive', 'car.rb')
-      ]
-      expect(bestMatch(candidates, 'car.rb')).toBe candidates[0]
-
-      candidates = [
-        path.join('app', 'models', 'cars', 'car.rb')
-        path.join('spec', 'cars.rb')
-      ]
-      expect(bestMatch(candidates, 'car.rb')).toBe candidates[0]
-
-      candidates = [
-        path.join('test', 'components', 'core', 'application', 'applicationPageStateServiceSpec.js')
-        path.join('test', 'components', 'core', 'view', 'components', 'actions', 'actionsServiceSpec.js')
-      ]
-      expect(bestMatch(candidates, 'actionsServiceSpec.js')).toBe candidates[1]
-
-  describe "When multiple result can match", ->
-
-    it "returns the result in order", ->
       candidates = [
         'Find And Replace: Select All',
         'Settings View: Uninstall Packages',
@@ -328,6 +682,7 @@ describe "filtering", ->
         'Application: Install Update',
         'Install'
       ]
+
       result = filter(candidates, 'install')
       expect(result[0]).toBe candidates[4]
       expect(result[1]).toBe candidates[3]
@@ -335,22 +690,36 @@ describe "filtering", ->
       expect(result[3]).toBe candidates[1]
       expect(result[4]).toBe candidates[0]
 
-      #Even when we do not have an exact match
-      result = filter(candidates, 'Instll')
+      # Even when we do not have an exact match
+
+      result = filter(candidates, 'instll')
       expect(result[0]).toBe candidates[4]
       expect(result[1]).toBe candidates[3]
       expect(result[2]).toBe candidates[2]
       expect(result[3]).toBe candidates[1]
       expect(result[4]).toBe candidates[0]
 
+      # for this one, complete word "Install" should win against:
+      #
+      #  - case-sensitive end-of-word match "Uninstall",
+      #  - start of word match "Installed",
+      #  - double acronym match "in S t A ll" -> "Select All"
+      #
+      #  also "Install" by itself should win against "Install" in a sentence
+
 
     it "weighs substring higher than individual characters", ->
-    candidates = [
-      'Git Plus: Stage Hunk',
-      'Git Plus: Reset Head',
-      'Git Plus: Push',
-      'Git Plus: Show'
-    ]
-    expect(bestMatch(candidates, 'push')).toBe 'Git Plus: Push'
-    expect(bestMatch(['a0b0c', 'somethingabc'], 'abc')).toBe 'somethingabc'
-    expect(bestMatch(['a0b0c x', 'somethingabc x'], 'abcx')).toBe 'somethingabc x'
+
+      candidates = [
+        'Git Plus: Stage Hunk',
+        'Git Plus: Reset Head',
+        'Git Plus: Push',
+        'Git Plus: Show'
+      ]
+      expect(bestMatch(candidates, 'push')).toBe candidates[2]
+      expect(bestMatch(candidates, 'git push')).toBe candidates[2]
+      expect(bestMatch(candidates, 'gpush')).toBe candidates[2]
+
+      # Here "Plus Stage Hunk" accidentally match acronym on PuSH.
+      # Using two words disable exactMatch bonus, we have to rely on consecutive match
+

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -165,6 +165,31 @@ describe "filtering", ->
     expect(bestMatch(candidates, 'CCC')).toBe candidates[0]
     expect(bestMatch(candidates, 'ccc')).toBe candidates[1]
 
+  it "prefer CamelCase that happens sooner", ->
+
+    candidates = [
+      'anotherCamelCase',
+      'thisCamelCase000',
+    ]
+    expect(bestMatch(candidates, 'CC')).toBe candidates[1]
+
+  it "prefer CamelCase in shorter haystack", ->
+
+    candidates = [
+      'CamelCase0',
+      'CamelCase',
+    ]
+    expect(bestMatch(candidates, 'CC')).toBe candidates[1]
+
+  it "prefer uninterrupted sequence CamelCase", ->
+
+    candidates = [
+      'CamelSkippedCase',
+      'CamelCaseSkipped',
+    ]
+    expect(bestMatch(candidates, 'CC')).toBe candidates[1]
+
+
 
   describe "when the entries are of differing directory depths", ->
     it "places exact matches first, even if they're deeper", ->

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -156,6 +156,15 @@ describe "filtering", ->
     expect(bestMatch(candidates, 'FFT')).toBe 'FilterFactorTests.html'
     expect(bestMatch(candidates, 'fft')).toBe 'FilterFactorTests.html'
 
+  it "account for case in CamelCase vs Substring matches", ->
+
+    candidates = [
+      'CamelCaseClass.js',
+      'cccManager.java'
+    ]
+    expect(bestMatch(candidates, 'CCC')).toBe candidates[0]
+    expect(bestMatch(candidates, 'ccc')).toBe candidates[1]
+
 
   describe "when the entries are of differing directory depths", ->
     it "places exact matches first, even if they're deeper", ->

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -125,6 +125,19 @@ describe "filtering", ->
 
       expect(bestMatch(candidate, "modeluser")).toBe candidate[1]
 
+    it "allow to match using wrong slash, space or colon", ->
+      candidate = [
+        path.join('foo', 'bar'),
+        path.join('model', 'user'),
+      ]
+
+      expect(bestMatch(candidate, "model user")).toBe candidate[1]
+      expect(bestMatch(candidate, "model/user")).toBe candidate[1]
+      expect(bestMatch(candidate, "model\\user")).toBe candidate[1]
+      expect(bestMatch(candidate, "model::user")).toBe candidate[1]
+
+
+
   describe "when the query contains slashes", ->
     it "weighs basename matches higher", ->
       candidates = [

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -281,7 +281,7 @@ describe "filtering", ->
         'Settings View: Uninstall Packages',
         'Settings View: View Installed Themes',
         'Application: Install Update',
-        'install'
+        'Install'
       ]
       result = filter(candidates, 'install')
       expect(result[0]).toBe candidates[4]

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -167,9 +167,14 @@ describe "filtering", ->
       expect(bestMatch(candidates, 'Status')).toBe 'StatusUrl'
       expect(bestMatch(candidates, 'SU')).toBe 'StatusUrl'
       expect(bestMatch(candidates, 'status')).toBe 'statusurl'
-      expect(bestMatch(candidates, 'su')).toBe 'statusurl'
       expect(bestMatch(candidates, 'statusurl')).toBe 'statusurl'
       expect(bestMatch(candidates, 'StatusUrl')).toBe 'StatusUrl'
+
+    it "account for case while selecting an acronym", ->
+      candidates = ['statusurl', 'status_url', 'StatusUrl']
+      expect(bestMatch(candidates, 'SU')).toBe 'StatusUrl'
+      expect(bestMatch(candidates, 'su')).toBe 'status_url'
+
 
     it "weighs exact case matches higher even if string is longer", ->
       candidates = ['Diagnostic', 'diagnostics0000']

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -112,6 +112,21 @@ describe "filtering", ->
 
       expect(bestMatch(candidates, 'core')).toBe candidates[1]
 
+    it "prefer single letter start-of-word exact match vs longer query", ->
+
+      candidates = [
+        'Timecop:View',
+        'Markdown Preview: Copy Html'
+      ]
+      expect(bestMatch(candidates, 'm')).toBe candidates[1]
+
+      candidates = [
+        'Welcome:show',
+        'Markdown Preview: Toggle Break On Newline'
+      ]
+      expect(bestMatch(candidates, 'm')).toBe candidates[1]
+
+
 
   #---------------------------------------------------
   #
@@ -396,6 +411,9 @@ describe "filtering", ->
       #then for general purpose match.
       expect(bestMatch(candidates, 'CCCa')).toBe candidates[0]
       expect(bestMatch(candidates, 'ccca')).toBe candidates[1]
+
+
+
 
 
   #---------------------------------------------------

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -29,6 +29,17 @@ describe "filtering", ->
     candidates = ['Gruntfile xx', 'filter xx', 'bile xx']
     expect(bestMatch(candidates, 'filex')).toBe candidates[0]
 
+  describe "when query is exact match", ->
+    it "prefer match at word boundary (string limit)", ->
+    candidates = ['gruntfilea', 'agruntfile']
+    expect(bestMatch(candidates, 'file')).toBe candidates[1]
+    expect(bestMatch(candidates, 'grunt')).toBe candidates[0]
+
+    it "prefer match at word boundary (separator limit)", ->
+    candidates = ['hello gruntfilea world', 'hello agruntfile world']
+    expect(bestMatch(candidates, 'file')).toBe candidates[1]
+    expect(bestMatch(candidates, 'grunt')).toBe candidates[0]
+
   describe "when the entries contains slashes", ->
     it "weighs basename matches higher", ->
       candidates = [
@@ -114,9 +125,6 @@ describe "filtering", ->
 
       expect(bestMatch(candidate, "modeluser")).toBe candidate[1]
 
-
-
-
   describe "when the query contains slashes", ->
     it "weighs basename matches higher", ->
       candidates = [
@@ -165,7 +173,6 @@ describe "filtering", ->
     it "weighs exact case matches higher", ->
       candidates = ['statusurl', 'StatusUrl']
       expect(bestMatch(candidates, 'Status')).toBe 'StatusUrl'
-      expect(bestMatch(candidates, 'SU')).toBe 'StatusUrl'
       expect(bestMatch(candidates, 'status')).toBe 'statusurl'
       expect(bestMatch(candidates, 'statusurl')).toBe 'statusurl'
       expect(bestMatch(candidates, 'StatusUrl')).toBe 'StatusUrl'
@@ -174,7 +181,7 @@ describe "filtering", ->
       candidates = ['statusurl', 'status_url', 'StatusUrl']
       expect(bestMatch(candidates, 'SU')).toBe 'StatusUrl'
       expect(bestMatch(candidates, 'su')).toBe 'status_url'
-
+      expect(bestMatch(candidates, 'st')).toBe 'statusurl'
 
     it "weighs exact case matches higher even if string is longer", ->
       candidates = ['Diagnostic', 'diagnostics0000']
@@ -302,7 +309,7 @@ describe "filtering", ->
 
     it "returns the result in order", ->
       candidates = [
-        'Find And Replace: Selet All',
+        'Find And Replace: Select All',
         'Settings View: Uninstall Packages',
         'Settings View: View Installed Themes',
         'Application: Install Update',

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -16,12 +16,12 @@ rootPath = (segments...) ->
 describe "filtering", ->
   it "returns an array of the most accurate results", ->
     candidates = ['Gruntfile','filter', 'bile', null, '', undefined]
-    expect(filter(candidates, 'file')).toEqual ['filter', 'Gruntfile']
+    expect(filter(candidates, 'file')).toEqual ['Gruntfile', 'filter']
 
   describe "when the maxResults option is set", ->
     it "limits the results to the result size", ->
       candidates = ['Gruntfile', 'filter', 'bile']
-      expect(bestMatch(candidates, 'file')).toBe 'filter'
+      expect(bestMatch(candidates, 'file')).toBe 'Gruntfile'
 
   describe "when the entries contains slashes", ->
     it "weighs basename matches higher", ->
@@ -111,6 +111,31 @@ describe "filtering", ->
     expect(bestMatch(['a_b_c', 'a_b'], 'ab')).toBe 'a_b'
     expect(bestMatch(['z_a_b', 'a_b'], 'ab')).toBe 'a_b'
     expect(bestMatch(['a_b_c', 'c_a_b'], 'ab')).toBe 'a_b_c'
+    expect(bestMatch(['Unin-stall', path.join('dir1', 'dir2', 'dir3', 'Installation')], 'install')).toBe path.join('dir1', 'dir2', 'dir3', 'Installation')
+    expect(bestMatch(['Uninstall', path.join('dir', 'Install')], 'install')).toBe path.join('dir', 'Install')
+
+  it "weighs substring higher than individual characters", ->
+    candidates = [
+      'Git Plus: Stage Hunk',
+      'Git Plus: Reset Head',
+      'Git Plus: Push',
+      'Git Plus: Show'
+    ]
+    expect(bestMatch(candidates, 'push')).toBe 'Git Plus: Push'
+    expect(bestMatch(['a_b_c', 'somethingabc'], 'abc')).toBe 'somethingabc'
+
+  it "returns the result in order", ->
+    candidates = [
+      'Find And Replace: Selet All',
+      'Settings View: Uninstall Packages',
+      'Application: Install Update',
+      'install'
+    ]
+    result = filter(candidates, 'install')
+    expect(result[0]).toBe candidates[3]
+    expect(result[1]).toBe candidates[2]
+    expect(result[2]).toBe candidates[1]
+    expect(result[3]).toBe candidates[0]
 
   describe "when the entries are of differing directory depths", ->
     it "places exact matches first, even if they're deeper", ->

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -154,6 +154,8 @@ describe "filtering", ->
       'SpecFilterFactors.js'
     ]
     expect(bestMatch(candidates, 'FFT')).toBe 'FilterFactorTests.html'
+    expect(bestMatch(candidates, 'fft')).toBe 'FilterFactorTests.html'
+
 
   describe "when the entries are of differing directory depths", ->
     it "places exact matches first, even if they're deeper", ->

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -6,7 +6,7 @@ bestMatch = (candidates, query) ->
 
 rootPath = (segments...) ->
   joinedPath = if process.platform is 'win32' then 'C:\\' else '/'
-  # joinedPath = path.sep
+  #joinedPath = path.sep
   for segment in segments
     if segment is path.sep
       joinedPath += segment
@@ -16,7 +16,7 @@ rootPath = (segments...) ->
 
 describe "filtering", ->
   it "returns an array of the most accurate results", ->
-    candidates = ['Gruntfile','filter', 'bile', null, '', undefined]
+    candidates = ['Gruntfile', 'filter', 'bile', null, '', undefined]
     expect(filter(candidates, 'file')).toEqual ['Gruntfile', 'filter']
 
   describe "when the maxResults option is set", ->
@@ -58,8 +58,37 @@ describe "filtering", ->
       ]
       expect(bestMatch(candidates, 'bar')).toBe candidates[1]
 
-      expect(bestMatch([path.join('f', 'o', '1_a_z'), path.join('f', 'o', 'a_z')], 'az')).toBe path.join('f', 'o', 'a_z')
+      expect(bestMatch([path.join('f', 'o', '1_a_z'), path.join('f', 'o', 'a_z')], 'az')).toBe path.join('f', 'o',
+        'a_z')
       expect(bestMatch([path.join('f', '1_a_z'), path.join('f', 'o', 'a_z')], 'az')).toBe path.join('f', 'o', 'a_z')
+
+    it "prefer shallow path", ->
+
+      candidate = [
+        path.join('b', 'z', 'file'),
+        path.join('b_z', 'file')
+      ]
+
+      expect(bestMatch(candidate, "file")).toBe candidate[1]
+      expect(bestMatch(candidate, "fle")).toBe candidate[1]
+
+      candidate = [
+        path.join('foo', 'bar', 'baz', 'file'),
+        path.join('foo', 'bar_baz', 'file')
+      ]
+
+      expect(bestMatch(candidate, "file")).toBe candidate[1]
+      expect(bestMatch(candidate, "fle")).toBe candidate[1]
+
+    it "allow to search structure", ->
+      candidate = [
+        path.join('base', 'file'),
+        path.join('bar', 'file')
+      ]
+
+      expect(bestMatch(candidate, "base file")).toBe candidate[0]
+      expect(bestMatch(candidate, "as fle")).toBe candidate[0]
+
 
   describe "when the candidate is all slashes", ->
     it "does not throw an exception", ->
@@ -112,7 +141,8 @@ describe "filtering", ->
     expect(bestMatch(['a_b_c', 'a_b'], 'ab')).toBe 'a_b'
     expect(bestMatch(['z_a_b', 'a_b'], 'ab')).toBe 'a_b'
     expect(bestMatch(['a_b_c', 'c_a_b'], 'ab')).toBe 'a_b_c'
-    expect(bestMatch(['Unin-stall', path.join('dir1', 'dir2', 'dir3', 'Installation')], 'install')).toBe path.join('dir1', 'dir2', 'dir3', 'Installation')
+    expect(bestMatch(['Unin-stall', path.join('dir1', 'dir2', 'dir3', 'Installation')],
+      'install')).toBe path.join('dir1', 'dir2', 'dir3', 'Installation')
     expect(bestMatch(['Uninstall', path.join('dir', 'Install')], 'install')).toBe path.join('dir', 'Install')
 
   it "weighs CamelCase matches higher", ->
@@ -124,13 +154,6 @@ describe "filtering", ->
       'SpecFilterFactors.js'
     ]
     expect(bestMatch(candidates, 'FFT')).toBe 'FilterFactorTests.html'
-
-    # expect(bestMatch(candidates, 'fft')).toBe 'FilterFactorTests.html'
-
-    # lowecase fft is in conflict with
-    #    expect(bestMatch(candidates, 'statusurl')).toBe 'statusurl'
-    # because that expectation reject an acronym match to favor matching same case.
-    # (still a possibility to go around it by detecting fft is nothing but acronym)
 
   describe "when the entries are of differing directory depths", ->
     it "places exact matches first, even if they're deeper", ->
@@ -158,9 +181,13 @@ describe "filtering", ->
       ]
       expect(bestMatch(candidates, 'car.rb')).toBe candidates[0]
 
+      candidates = [
+        path.join('test', 'components', 'core', 'application', 'applicationPageStateServiceSpec.js')
+        path.join('test', 'components', 'core', 'view', 'components', 'actions', 'actionsServiceSpec.js')
+      ]
+      expect(bestMatch(candidates, 'actionsServiceSpec.js')).toBe candidates[1]
 
   describe "When multiple result can match", ->
-
     it "returns the result in order", ->
       candidates = [
         'Find And Replace: Selet All',

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -115,31 +115,22 @@ describe "filtering", ->
     expect(bestMatch(['Unin-stall', path.join('dir1', 'dir2', 'dir3', 'Installation')], 'install')).toBe path.join('dir1', 'dir2', 'dir3', 'Installation')
     expect(bestMatch(['Uninstall', path.join('dir', 'Install')], 'install')).toBe path.join('dir', 'Install')
 
-  it "weighs substring higher than individual characters", ->
+  it "weighs CamelCase matches higher", ->
     candidates = [
-      'Git Plus: Stage Hunk',
-      'Git Plus: Reset Head',
-      'Git Plus: Push',
-      'Git Plus: Show'
+      'FilterFactors.js',
+      'FilterFactors.styl',
+      'FilterFactors.html',
+      'FilterFactorTests.html',
+      'SpecFilterFactors.js'
     ]
-    expect(bestMatch(candidates, 'push')).toBe 'Git Plus: Push'
-    expect(bestMatch(['a_b_c', 'somethingabc'], 'abc')).toBe 'somethingabc'
+    expect(bestMatch(candidates, 'FFT')).toBe 'FilterFactorTests.html'
 
-  it "returns the result in order", ->
-    candidates = [
-      'Find And Replace: Selet All',
-      'Settings View: Uninstall Packages',
-      'Settings View: View Installed Themes',
-      'Application: Install Update',
-      'install'
-    ]
-    result = filter(candidates, 'install')
-    expect(result[0]).toBe candidates[4]
-    expect(result[1]).toBe candidates[3]
-    expect(result[2]).toBe candidates[2]
-    expect(result[3]).toBe candidates[1]
-    expect(result[4]).toBe candidates[0]
+    # expect(bestMatch(candidates, 'fft')).toBe 'FilterFactorTests.html'
 
+    # lowecase fft is in conflict with
+    #    expect(bestMatch(candidates, 'statusurl')).toBe 'statusurl'
+    # because that expectation reject an acronym match to favor matching same case.
+    # (still a possibility to go around it by detecting fft is nothing but acronym)
 
   describe "when the entries are of differing directory depths", ->
     it "places exact matches first, even if they're deeper", ->
@@ -166,3 +157,31 @@ describe "filtering", ->
         path.join('spec', 'cars.rb')
       ]
       expect(bestMatch(candidates, 'car.rb')).toBe candidates[0]
+
+
+  describe "When multiple result can match", ->
+
+    it "returns the result in order", ->
+      candidates = [
+        'Find And Replace: Selet All',
+        'Settings View: Uninstall Packages',
+        'Settings View: View Installed Themes',
+        'Application: Install Update',
+        'install'
+      ]
+      result = filter(candidates, 'install')
+      expect(result[0]).toBe candidates[4]
+      expect(result[1]).toBe candidates[3]
+      expect(result[2]).toBe candidates[2]
+      expect(result[3]).toBe candidates[1]
+      expect(result[4]).toBe candidates[0]
+
+    it "weighs substring higher than individual characters", ->
+    candidates = [
+      'Git Plus: Stage Hunk',
+      'Git Plus: Reset Head',
+      'Git Plus: Push',
+      'Git Plus: Show'
+    ]
+    expect(bestMatch(candidates, 'push')).toBe 'Git Plus: Push'
+    expect(bestMatch(['a_b_c', 'somethingabc'], 'abc')).toBe 'somethingabc'

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -189,16 +189,15 @@ describe "filtering", ->
       expect(bestMatch(candidates, 'fft.html')).toBe 'FilterFactorTests.html'
 
 
-    it "weighs CamelCase matches higher than middle of word exact matches, or snake_abbrv", ->
+    it "weighs Abbreviation matches higher than middle of word", ->
 
       candidates = [
         'switch.css',
-        'user_id_to_client',
+        'userid_to_client',
         'ImportanceTableCtrl.js'
       ]
       expect(bestMatch(candidates, 'itc')).toBe candidates[2]
       expect(bestMatch(candidates, 'ITC')).toBe candidates[2]
-      expect(bestMatch(candidates, 'itcl')).toBe candidates[2]
 
 
     it "account for case in CamelCase vs Substring matches", ->
@@ -299,13 +298,6 @@ describe "filtering", ->
       expect(result[3]).toBe candidates[1]
       expect(result[4]).toBe candidates[0]
 
-      #Start of word VS proper case.
-      #result = filter(candidates, 'instll')
-      #expect(result[0]).toBe candidates[4]
-      #expect(result[1]).toBe candidates[3]
-      #expect(result[2]).toBe candidates[2]
-      #expect(result[3]).toBe candidates[1]
-      #expect(result[4]).toBe candidates[0]
 
     it "weighs substring higher than individual characters", ->
     candidates = [
@@ -315,5 +307,5 @@ describe "filtering", ->
       'Git Plus: Show'
     ]
     expect(bestMatch(candidates, 'push')).toBe 'Git Plus: Push'
-    expect(bestMatch(['a_b_c', 'somethingabc'], 'abc')).toBe 'somethingabc'
-    expect(bestMatch(['a_b_c x', 'somethingabc x'], 'abcx')).toBe 'somethingabc x'
+    expect(bestMatch(['a0b0c', 'somethingabc'], 'abc')).toBe 'somethingabc'
+    expect(bestMatch(['a0b0c x', 'somethingabc x'], 'abcx')).toBe 'somethingabc x'

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -6,6 +6,7 @@ bestMatch = (candidates, query) ->
 
 rootPath = (segments...) ->
   joinedPath = if process.platform is 'win32' then 'C:\\' else '/'
+  # joinedPath = path.sep
   for segment in segments
     if segment is path.sep
       joinedPath += segment
@@ -128,14 +129,17 @@ describe "filtering", ->
     candidates = [
       'Find And Replace: Selet All',
       'Settings View: Uninstall Packages',
+      'Settings View: View Installed Themes',
       'Application: Install Update',
       'install'
     ]
     result = filter(candidates, 'install')
-    expect(result[0]).toBe candidates[3]
-    expect(result[1]).toBe candidates[2]
-    expect(result[2]).toBe candidates[1]
-    expect(result[3]).toBe candidates[0]
+    expect(result[0]).toBe candidates[4]
+    expect(result[1]).toBe candidates[3]
+    expect(result[2]).toBe candidates[2]
+    expect(result[3]).toBe candidates[1]
+    expect(result[4]).toBe candidates[0]
+
 
   describe "when the entries are of differing directory depths", ->
     it "places exact matches first, even if they're deeper", ->

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -292,12 +292,20 @@ describe "filtering", ->
       expect(result[4]).toBe candidates[0]
 
       #Even when we do not have an exact match
-      result = filter(candidates, 'instll')
+      result = filter(candidates, 'Instll')
       expect(result[0]).toBe candidates[4]
       expect(result[1]).toBe candidates[3]
       expect(result[2]).toBe candidates[2]
       expect(result[3]).toBe candidates[1]
       expect(result[4]).toBe candidates[0]
+
+      #Start of word VS proper case.
+      #result = filter(candidates, 'instll')
+      #expect(result[0]).toBe candidates[4]
+      #expect(result[1]).toBe candidates[3]
+      #expect(result[2]).toBe candidates[2]
+      #expect(result[3]).toBe candidates[1]
+      #expect(result[4]).toBe candidates[0]
 
     it "weighs substring higher than individual characters", ->
     candidates = [

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -186,6 +186,8 @@ describe "filtering", ->
       ]
       expect(bestMatch(candidates, 'FFT')).toBe 'FilterFactorTests.html'
       expect(bestMatch(candidates, 'fft')).toBe 'FilterFactorTests.html'
+      expect(bestMatch(candidates, 'fft.html')).toBe 'FilterFactorTests.html'
+
 
     it "weighs CamelCase matches higher than middle of word exact matches, or snake_abbrv", ->
 
@@ -196,6 +198,7 @@ describe "filtering", ->
       ]
       expect(bestMatch(candidates, 'itc')).toBe candidates[2]
       expect(bestMatch(candidates, 'ITC')).toBe candidates[2]
+      expect(bestMatch(candidates, 'itcl')).toBe candidates[2]
 
 
     it "account for case in CamelCase vs Substring matches", ->
@@ -272,6 +275,7 @@ describe "filtering", ->
       expect(bestMatch(candidates, 'actionsServiceSpec.js')).toBe candidates[1]
 
   describe "When multiple result can match", ->
+
     it "returns the result in order", ->
       candidates = [
         'Find And Replace: Selet All',
@@ -281,6 +285,14 @@ describe "filtering", ->
         'install'
       ]
       result = filter(candidates, 'install')
+      expect(result[0]).toBe candidates[4]
+      expect(result[1]).toBe candidates[3]
+      expect(result[2]).toBe candidates[2]
+      expect(result[3]).toBe candidates[1]
+      expect(result[4]).toBe candidates[0]
+
+      #Even when we do not have an exact match
+      result = filter(candidates, 'instll')
       expect(result[0]).toBe candidates[4]
       expect(result[1]).toBe candidates[3]
       expect(result[2]).toBe candidates[2]

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -88,7 +88,7 @@ describe "filtering", ->
       expect(bestMatch(candidate, "file")).toBe candidate[1]
       expect(bestMatch(candidate, "fle")).toBe candidate[1]
 
-    it "allow to folder path", ->
+    it "allow to match in folder path", ->
       candidate = [
         path.join('base', 'file'),
         path.join('bar', 'file')
@@ -96,6 +96,26 @@ describe "filtering", ->
 
       expect(bestMatch(candidate, "base file")).toBe candidate[0]
       expect(bestMatch(candidate, "as fle")).toBe candidate[0]
+
+    it "prefer full path almost exact match, to match in file only", ->
+
+      candidate = [
+        path.join('models', 'user.b'),
+        path.join('migrate', 'moderator_column_users.rb')
+      ]
+
+      expect(bestMatch(candidate, "modeluser")).toBe candidate[0]
+      expect(bestMatch(candidate, "migrateuser")).toBe candidate[1]
+
+      candidate = [
+        path.join('models', 'user.b'),
+        path.join('migrate', 'model_users.rb')
+      ]
+
+      expect(bestMatch(candidate, "modeluser")).toBe candidate[1]
+
+
+
 
   describe "when the query contains slashes", ->
     it "weighs basename matches higher", ->

--- a/spec/legacy-filter-spec.coffee
+++ b/spec/legacy-filter-spec.coffee
@@ -1,0 +1,142 @@
+path = require 'path'
+fuzzaldrin = require '../src/fuzzaldrin'
+
+filter = (candidates, query) ->
+  fuzzaldrin.filter(candidates, query, {legacy:true})
+
+bestMatch = (candidates, query) ->
+  fuzzaldrin.filter(candidates, query, { maxResults: 1, legacy:true})[0]
+
+rootPath = (segments...) ->
+  joinedPath = if process.platform is 'win32' then 'C:\\' else '/'
+  for segment in segments
+    if segment is path.sep
+      joinedPath += segment
+    else
+      joinedPath = path.join(joinedPath, segment)
+  joinedPath
+
+describe "filtering", ->
+  it "returns an array of the most accurate results", ->
+    candidates = ['Gruntfile','filter', 'bile', null, '', undefined]
+    expect(filter(candidates, 'file')).toEqual ['filter', 'Gruntfile']
+
+  describe "when the maxResults option is set", ->
+    it "limits the results to the result size", ->
+      candidates = ['Gruntfile', 'filter', 'bile']
+      expect(bestMatch(candidates, 'file')).toBe 'filter'
+
+  describe "when the entries contains slashes", ->
+    it "weighs basename matches higher", ->
+      candidates = [
+        rootPath('bar', 'foo')
+        rootPath('foo', 'bar')
+      ]
+      expect(bestMatch(candidates, 'bar')).toBe candidates[1]
+
+      candidates = [
+        rootPath('bar', 'foo')
+        rootPath('foo', 'bar', path.sep, path.sep, path.sep, path.sep, path.sep)
+      ]
+      expect(bestMatch(candidates, 'bar')).toBe candidates[1]
+
+      candidates = [
+        rootPath('bar', 'foo')
+        rootPath('foo', 'bar')
+        'bar'
+      ]
+      expect(bestMatch(candidates, 'bar')).toEqual candidates[2]
+
+      candidates = [
+        rootPath('bar', 'foo')
+        rootPath('foo', 'bar')
+        rootPath('bar')
+      ]
+      expect(bestMatch(candidates, 'bar')).toBe candidates[2]
+
+      candidates = [
+        rootPath('bar', 'foo')
+        "bar#{path.sep}#{path.sep}#{path.sep}#{path.sep}#{path.sep}#{path.sep}"
+      ]
+      expect(bestMatch(candidates, 'bar')).toBe candidates[1]
+
+      expect(bestMatch([path.join('f', 'o', '1_a_z'), path.join('f', 'o', 'a_z')], 'az')).toBe path.join('f', 'o', 'a_z')
+      expect(bestMatch([path.join('f', '1_a_z'), path.join('f', 'o', 'a_z')], 'az')).toBe path.join('f', 'o', 'a_z')
+
+  describe "when the candidate is all slashes", ->
+    it "does not throw an exception", ->
+      candidates = [path.sep]
+      expect(filter(candidates, 'bar', maxResults: 1)).toEqual []
+
+  describe "when the entries contains spaces", ->
+    it "treats spaces as slashes", ->
+      candidates = [
+        rootPath('bar', 'foo')
+        rootPath('foo', 'bar')
+      ]
+      expect(bestMatch(candidates, 'br f')).toBe candidates[0]
+
+    it "weighs basename matches higher", ->
+      candidates = [
+        rootPath('bar', 'foo')
+        rootPath('foo', 'bar foo')
+      ]
+      expect(bestMatch(candidates, 'br f')).toBe candidates[1]
+
+      candidates = [
+        rootPath('barfoo', 'foo')
+        rootPath('foo', 'barfoo')
+      ]
+      expect(bestMatch(candidates, 'br f')).toBe candidates[1]
+
+      candidates = [
+        path.join('lib', 'exportable.rb')
+        path.join('app', 'models', 'table.rb')
+      ]
+      expect(bestMatch(candidates, 'table')).toBe candidates[1]
+
+  describe "when the entries contains mixed case", ->
+    it "weighs exact case matches higher", ->
+      candidates = ['statusurl', 'StatusUrl']
+      expect(bestMatch(candidates, 'Status')).toBe 'StatusUrl'
+      expect(bestMatch(candidates, 'SU')).toBe 'StatusUrl'
+      expect(bestMatch(candidates, 'status')).toBe 'statusurl'
+      expect(bestMatch(candidates, 'su')).toBe 'statusurl'
+      expect(bestMatch(candidates, 'statusurl')).toBe 'statusurl'
+      expect(bestMatch(candidates, 'StatusUrl')).toBe 'StatusUrl'
+
+  it "weighs abbreviation matches after spaces, underscores, and dashes the same", ->
+    expect(bestMatch(['sub-zero', 'sub zero', 'sub_zero'], 'sz')).toBe 'sub-zero'
+    expect(bestMatch(['sub zero', 'sub_zero', 'sub-zero'], 'sz')).toBe 'sub zero'
+    expect(bestMatch(['sub_zero', 'sub-zero', 'sub zero'], 'sz')).toBe 'sub_zero'
+
+  it "weighs matches at the start of the string or base name higher", ->
+    expect(bestMatch(['a_b_c', 'a_b'], 'ab')).toBe 'a_b'
+    expect(bestMatch(['z_a_b', 'a_b'], 'ab')).toBe 'a_b'
+    expect(bestMatch(['a_b_c', 'c_a_b'], 'ab')).toBe 'a_b_c'
+
+  describe "when the entries are of differing directory depths", ->
+    it "places exact matches first, even if they're deeper", ->
+      candidates = [
+        path.join('app', 'models', 'automotive', 'car.rb')
+        path.join('spec', 'factories', 'cars.rb')
+      ]
+      expect(bestMatch(candidates, 'car.rb')).toBe candidates[0]
+
+      candidates = [
+        path.join('app', 'models', 'automotive', 'car.rb')
+        'car.rb'
+      ]
+      expect(bestMatch(candidates, 'car.rb')).toBe candidates[1]
+
+      candidates = [
+        'car.rb',
+        path.join('app', 'models', 'automotive', 'car.rb')
+      ]
+      expect(bestMatch(candidates, 'car.rb')).toBe candidates[0]
+
+      candidates = [
+        path.join('app', 'models', 'cars', 'car.rb')
+        path.join('spec', 'cars.rb')
+      ]
+      expect(bestMatch(candidates, 'car.rb')).toBe candidates[0]

--- a/spec/match-spec.coffee
+++ b/spec/match-spec.coffee
@@ -58,7 +58,17 @@ describe "match(string, query)", ->
     expect(match('0xACACAC: CamelControlClass.ccc', 'CCC')).toEqual [ 10, 15, 22]
     expect(match('0xACACAC: CamelControlClass.ccc', 'ccc')).toEqual [ 28, 29, 30]
 
+  it "limit consecutive inside word boundary", ->
 
+    #expect(match('Interns And Roles - Patterns Roles', 'interns roles')).toEqual [ 0, 1, 2, 3, 4, 5, 6, 7, 12, 13, 14, 15, 16]
+    #
+    # the longest substring is "terns roles"
+    # it's also not very intuitive to split the word interns like that.
+    # limit consecutive at word boundary will help to prevent spiting words.
+    #
+    # Aside from doing more computation while scanning consecutive.
+    # The main problem is that we don't reset the consecutive count unless we encounter a negative match.
+    #
 
 
 

--- a/spec/match-spec.coffee
+++ b/spec/match-spec.coffee
@@ -57,7 +57,7 @@ describe "match(string, query)", ->
   it "account for case in selecting camelCase vs consecutive", ->
     expect(match('0xACACAC: CamelControlClass.accc', 'CCC')).toEqual [ 10, 15, 22]
     expect(match('0xACACAC: CamelControlClass.accc', 'ccc')).toEqual [ 29, 30, 31]
-    expect(match('0xACACAC: CamelControlClass.accc xfiller', 'cccx')).toEqual [ 29, 30, 31, 33]
+    #expect(match('0xACACAC: CamelControlClass.accc xfiller', 'cccx')).toEqual [ 29, 30, 31, 33]
 
     expect(match('0xACACAC: CamelControlClass', 'ccc')).toEqual [ 10, 15, 22]
     expect(match('0xACACAC: CamelControlClass', 'CCC')).toEqual [ 10, 15, 22]

--- a/spec/match-spec.coffee
+++ b/spec/match-spec.coffee
@@ -55,9 +55,9 @@ describe "match(string, query)", ->
     expect(match('application_control', 'acon')).toEqual [ 0, 12, 13, 14]
 
   it "account for case in selecting camelCase vs consecutive", ->
-    expect(match('0xACACAC: CamelControlClass.accc', 'CCC')).toEqual [ 10, 15, 22]
-    expect(match('0xACACAC: CamelControlClass.accc', 'ccc')).toEqual [ 29, 30, 31]
-    #expect(match('0xACACAC: CamelControlClass.accc xfiller', 'cccx')).toEqual [ 29, 30, 31, 33]
+    expect(match('0xACACAC: CamelControlClass.ccc', 'CCC')).toEqual [ 10, 15, 22]
+    expect(match('0xACACAC: CamelControlClass.ccc', 'ccc')).toEqual [ 28, 29, 30]
+    expect(match('0xACACAC: CamelControlClass.ccc xfiller', 'cccx')).toEqual [ 28, 29, 30, 32]
 
     expect(match('0xACACAC: CamelControlClass', 'ccc')).toEqual [ 10, 15, 22]
     expect(match('0xACACAC: CamelControlClass', 'CCC')).toEqual [ 10, 15, 22]

--- a/spec/match-spec.coffee
+++ b/spec/match-spec.coffee
@@ -57,10 +57,6 @@ describe "match(string, query)", ->
   it "account for case in selecting camelCase vs consecutive", ->
     expect(match('0xACACAC: CamelControlClass.ccc', 'CCC')).toEqual [ 10, 15, 22]
     expect(match('0xACACAC: CamelControlClass.ccc', 'ccc')).toEqual [ 28, 29, 30]
-    expect(match('0xACACAC: CamelControlClass.ccc xfiller', 'cccx')).toEqual [ 28, 29, 30, 32]
-
-    expect(match('0xACACAC: CamelControlClass', 'ccc')).toEqual [ 10, 15, 22]
-    expect(match('0xACACAC: CamelControlClass', 'CCC')).toEqual [ 10, 15, 22]
 
 
 

--- a/spec/match-spec.coffee
+++ b/spec/match-spec.coffee
@@ -55,10 +55,12 @@ describe "match(string, query)", ->
     expect(match('application_control', 'acon')).toEqual [ 0, 12, 13, 14]
 
   it "account for case in selecting camelCase vs consecutive", ->
-    expect(match('0xACACAC: CamelControlClass.ccc', 'CCC')).toEqual [ 10, 15, 22]
-    expect(match('0xACACAC: CamelControlClass.ccc', 'ccc')).toEqual [ 28, 29, 30]
-    expect(match('0xACACAC: CamelControlClass.ccc xfiller', 'cccx')).toEqual [ 28, 29, 30, 32]
+    expect(match('0xACACAC: CamelControlClass.accc', 'CCC')).toEqual [ 10, 15, 22]
+    expect(match('0xACACAC: CamelControlClass.accc', 'ccc')).toEqual [ 29, 30, 31]
+    expect(match('0xACACAC: CamelControlClass.accc xfiller', 'cccx')).toEqual [ 29, 30, 31, 33]
+
     expect(match('0xACACAC: CamelControlClass', 'ccc')).toEqual [ 10, 15, 22]
+    expect(match('0xACACAC: CamelControlClass', 'CCC')).toEqual [ 10, 15, 22]
 
 
 

--- a/spec/score-spec.coffee
+++ b/spec/score-spec.coffee
@@ -3,7 +3,6 @@
 describe "score(string, query)", ->
   it "returns a score", ->
     expect(score('Hello World', 'he')).toBeLessThan(score('Hello World', 'Hello'))
-    #expect(score('Hello World', 'Hello World')).toBe 2 #No upper bound anymore
     expect(score('Hello World', '')).toBe 0
     expect(score('Hello World', null)).toBe 0
     expect(score('Hello World')).toBe 0

--- a/spec/score-spec.coffee
+++ b/spec/score-spec.coffee
@@ -3,7 +3,7 @@
 describe "score(string, query)", ->
   it "returns a score", ->
     expect(score('Hello World', 'he')).toBeLessThan(score('Hello World', 'Hello'))
-    expect(score('Hello World', 'Hello World')).toBe 2
+    #expect(score('Hello World', 'Hello World')).toBe 2 #No upper bound anymore
     expect(score('Hello World', '')).toBe 0
     expect(score('Hello World', null)).toBe 0
     expect(score('Hello World')).toBe 0

--- a/src/filter.coffee
+++ b/src/filter.coffee
@@ -7,9 +7,11 @@ sortCandidates = (a, b) -> b.score - a.score
 module.exports = (candidates, query, queryHasSlashes, {key, maxResults}={}) ->
   if query
     scoredCandidates = []
+    coreQuery = scorer.coreChars(query)
+
     for candidate in candidates
       string = if key? then candidate[key] else candidate
-      continue unless string
+      continue unless string and scorer.isMatch(string,coreQuery)
       score = scorer.score(string, query, queryHasSlashes)
       unless queryHasSlashes
         score = scorer.basenameScore(string, query, score)

--- a/src/filter.coffee
+++ b/src/filter.coffee
@@ -1,11 +1,12 @@
 scorer = require './scorer'
+legacy_scorer = require './legacy'
 
 pluckCandidates = (a) -> a.candidate
 sortCandidates = (a, b) -> b.score - a.score
 PathSeparator = require('path').sep
 
 
-module.exports = (candidates, query, {key, maxResults, allowErrors}={}) ->
+module.exports = (candidates, query, {key, maxResults, allowErrors, legacy }={}) ->
   if query
     scoredCandidates = []
 
@@ -19,12 +20,24 @@ module.exports = (candidates, query, {key, maxResults, allowErrors}={}) ->
     pos = query.indexOf(PathSeparator)
     baseQuery = if pos > -1 then query.substring(pos) else query
 
-    for candidate in candidates
-      string = if key? then candidate[key] else candidate
-      continue unless string and ( allowErrorsInQuery or scorer.isMatch(string,coreQuery) )
-      score = scorer.score(string, query)
-      score = scorer.basenameScore(string, baseQuery, score)
-      scoredCandidates.push({candidate, score}) if score > 0
+    if(not legacy)
+      for candidate in candidates
+        string = if key? then candidate[key] else candidate
+        continue unless string and ( allowErrorsInQuery or scorer.isMatch(string,coreQuery) )
+        score = scorer.score(string, query)
+        score = scorer.basenameScore(string, baseQuery, score)
+        scoredCandidates.push({candidate, score}) if score > 0
+
+    else
+      queryHasSlashes = pos > -1
+      for candidate in candidates
+        string = if key? then candidate[key] else candidate
+        continue unless string
+        score = legacy_scorer.score(string, coreQuery, queryHasSlashes)
+        unless queryHasSlashes
+          score = legacy_scorer.basenameScore(string, coreQuery, score)
+        scoredCandidates.push({candidate, score}) if score > 0
+
 
     # Sort scores in descending order
     scoredCandidates.sort(sortCandidates)

--- a/src/filter.coffee
+++ b/src/filter.coffee
@@ -5,39 +5,34 @@ pluckCandidates = (a) -> a.candidate
 sortCandidates = (a, b) -> b.score - a.score
 PathSeparator = require('path').sep
 
-
-module.exports = (candidates, query, {key, maxResults, maxInners, allowErrors, legacy }={}) ->
+module.exports = (candidates, query, {key, maxResults, maxInners, allowErrors, legacy, fuzzyWindow }={}) ->
 
   scoredCandidates = []
 
   # when query is to generic to select a few case, do reasonable effort to process results
   # then return to user to let him precise the query. (consider that many positive candidate
   # on the working list before going to sort and output maxResults best ones )
-  maxInners = 10000 unless maxInners?
-  spotLeft = if maxInners>0 then maxInners else candidates.length
+  maxInners ?= Math.max(2000, Math.floor(0.2*candidates.length))
+  spotLeft = if maxInners > 0 then maxInners else candidates.length
 
-  # allow any character of query to be optional (but better score if they are present)
-  allowErrorsInQuery = !!allowErrors
+  fuzzyWindow ?= scorer.defaultSearchWindow
 
-  # or allow only some characters to be optional, for example: space and space like characters
-  coreQuery = if allowErrorsInQuery then query else scorer.coreChars(query)
-  coreQuery_lw = coreQuery.toLowerCase()
-  query_lw = query.toLowerCase()
+  bAllowErrors = !!allowErrors
+  prepQuery = scorer.prepQuery(query)
 
   if(not legacy)
     for candidate in candidates
       string = if key? then candidate[key] else candidate
       continue unless string
-      string_lw = string.toLowerCase()
-      continue unless allowErrorsInQuery or scorer.isMatch(string_lw, coreQuery_lw)
-      score = scorer.score(string, query, string_lw, query_lw)
-      score = scorer.basenameScore(string, query, score, string_lw, query_lw)
+      score = scorer.score(string, query, prepQuery, bAllowErrors, fuzzyWindow)
       if score > 0
         scoredCandidates.push({candidate, score})
         break unless --spotLeft
 
   else
-    queryHasSlashes = query.indexOf(PathSeparator)> -1
+    queryHasSlashes = prepQuery.depth > 0
+    coreQuery = prepQuery.core
+
     for candidate in candidates
       string = if key? then candidate[key] else candidate
       continue unless string

--- a/src/filter.coffee
+++ b/src/filter.coffee
@@ -12,7 +12,7 @@ module.exports = (candidates, query, {key, maxResults, maxInners, allowErrors, l
 
     # when query is to generic to select a few case, do reasonable effort to process results
     # then return to user to let him precise the query. (consider that many positive candidate
-    # one the working list before going to sort and output maxResults best ones )
+    # on the working list before going to sort and output maxResults best ones )
     spotLeft = if maxInners>0 then maxInners else candidates.length
 
     # allow any character of query to be optional (but better score if they are present)

--- a/src/filter.coffee
+++ b/src/filter.coffee
@@ -7,50 +7,50 @@ PathSeparator = require('path').sep
 
 
 module.exports = (candidates, query, {key, maxResults, maxInners, allowErrors, legacy }={}) ->
-  if query
-    scoredCandidates = []
 
-    # when query is to generic to select a few case, do reasonable effort to process results
-    # then return to user to let him precise the query. (consider that many positive candidate
-    # on the working list before going to sort and output maxResults best ones )
-    maxInners = 10000 unless maxInners?
-    spotLeft = if maxInners>0 then maxInners else candidates.length
+  scoredCandidates = []
 
-    # allow any character of query to be optional (but better score if they are present)
-    allowErrorsInQuery = !!allowErrors
+  # when query is to generic to select a few case, do reasonable effort to process results
+  # then return to user to let him precise the query. (consider that many positive candidate
+  # on the working list before going to sort and output maxResults best ones )
+  maxInners = 10000 unless maxInners?
+  spotLeft = if maxInners>0 then maxInners else candidates.length
 
-    # or allow only some characters to be optional, for example: space and space like characters
-    coreQuery = if allowErrorsInQuery then query else scorer.coreChars(query)
-    coreQuery_lw = coreQuery.toLowerCase()
-    query_lw = query.toLowerCase()
+  # allow any character of query to be optional (but better score if they are present)
+  allowErrorsInQuery = !!allowErrors
 
-    if(not legacy)
-      for candidate in candidates
-        string = if key? then candidate[key] else candidate
-        continue unless string
-        string_lw = string.toLowerCase()
-        continue unless allowErrorsInQuery or scorer.isMatch(string_lw, coreQuery_lw)
-        score = scorer.score(string, query, string_lw, query_lw)
-        score = scorer.basenameScore(string, query, score, string_lw, query_lw)
-        if score > 0
-          scoredCandidates.push({candidate, score})
-          break unless --spotLeft
+  # or allow only some characters to be optional, for example: space and space like characters
+  coreQuery = if allowErrorsInQuery then query else scorer.coreChars(query)
+  coreQuery_lw = coreQuery.toLowerCase()
+  query_lw = query.toLowerCase()
 
-    else
-      queryHasSlashes = query.indexOf(PathSeparator)> -1
-      for candidate in candidates
-        string = if key? then candidate[key] else candidate
-        continue unless string
-        score = legacy_scorer.score(string, coreQuery, queryHasSlashes)
-        unless queryHasSlashes
-          score = legacy_scorer.basenameScore(string, coreQuery, score)
-        scoredCandidates.push({candidate, score}) if score > 0
+  if(not legacy)
+    for candidate in candidates
+      string = if key? then candidate[key] else candidate
+      continue unless string
+      string_lw = string.toLowerCase()
+      continue unless allowErrorsInQuery or scorer.isMatch(string_lw, coreQuery_lw)
+      score = scorer.score(string, query, string_lw, query_lw)
+      score = scorer.basenameScore(string, query, score, string_lw, query_lw)
+      if score > 0
+        scoredCandidates.push({candidate, score})
+        break unless --spotLeft
+
+  else
+    queryHasSlashes = query.indexOf(PathSeparator)> -1
+    for candidate in candidates
+      string = if key? then candidate[key] else candidate
+      continue unless string
+      score = legacy_scorer.score(string, coreQuery, queryHasSlashes)
+      unless queryHasSlashes
+        score = legacy_scorer.basenameScore(string, coreQuery, score)
+      scoredCandidates.push({candidate, score}) if score > 0
 
 
-    # Sort scores in descending order
-    scoredCandidates.sort(sortCandidates)
+  # Sort scores in descending order
+  scoredCandidates.sort(sortCandidates)
 
-    candidates = scoredCandidates.map(pluckCandidates)
+  candidates = scoredCandidates.map(pluckCandidates)
 
   candidates = candidates[0...maxResults] if maxResults?
   candidates

--- a/src/filter.coffee
+++ b/src/filter.coffee
@@ -13,6 +13,7 @@ module.exports = (candidates, query, {key, maxResults, maxInners, allowErrors, l
     # when query is to generic to select a few case, do reasonable effort to process results
     # then return to user to let him precise the query. (consider that many positive candidate
     # on the working list before going to sort and output maxResults best ones )
+    maxInners = 10000 unless maxInners?
     spotLeft = if maxInners>0 then maxInners else candidates.length
 
     # allow any character of query to be optional (but better score if they are present)
@@ -20,17 +21,22 @@ module.exports = (candidates, query, {key, maxResults, maxInners, allowErrors, l
 
     # or allow only some characters to be optional, for example: space and space like characters
     coreQuery = if allowErrorsInQuery then query else scorer.coreChars(query)
+    coreQuery_lw = coreQuery.toLowerCase()
 
     #get "file.ext" from "folder/file.ext"
     pos = query.indexOf(PathSeparator)
     baseQuery = if pos > -1 then query.substring(pos) else query
+    baseQuery_lw = baseQuery.toLowerCase()
+    query_lw = query.toLowerCase()
 
     if(not legacy)
       for candidate in candidates
         string = if key? then candidate[key] else candidate
-        continue unless string and ( allowErrorsInQuery or scorer.isMatch(string,coreQuery) )
-        score = scorer.score(string, query)
-        score = scorer.basenameScore(string, baseQuery, score)
+        continue unless string
+        string_lw = string.toLowerCase()
+        continue unless allowErrorsInQuery or scorer.isMatch(string_lw, coreQuery_lw)
+        score = scorer.score(string, query, string_lw, query_lw)
+        score = scorer.basenameScore(string, baseQuery, score, string_lw, baseQuery_lw)
         if score > 0
           scoredCandidates.push({candidate, score})
           break unless --spotLeft

--- a/src/filter.coffee
+++ b/src/filter.coffee
@@ -5,17 +5,10 @@ pluckCandidates = (a) -> a.candidate
 sortCandidates = (a, b) -> b.score - a.score
 PathSeparator = require('path').sep
 
-module.exports = (candidates, query, {key, maxResults, maxInners, allowErrors, legacy, fuzzyWindow }={}) ->
+module.exports = (candidates, query, {key, maxResults, maxInners, allowErrors, legacy }={}) ->
 
   scoredCandidates = []
-
-  # when query is to generic to select a few case, do reasonable effort to process results
-  # then return to user to let him precise the query. (consider that many positive candidate
-  # on the working list before going to sort and output maxResults best ones )
-  maxInners ?= Math.max(2000, Math.floor(0.2*candidates.length))
-  spotLeft = if maxInners > 0 then maxInners else candidates.length
-
-  fuzzyWindow ?= scorer.defaultSearchWindow
+  spotLeft = if maxInners? and  maxInners> 0 then maxInners else candidates.length
 
   bAllowErrors = !!allowErrors
   prepQuery = scorer.prepQuery(query)
@@ -24,7 +17,7 @@ module.exports = (candidates, query, {key, maxResults, maxInners, allowErrors, l
     for candidate in candidates
       string = if key? then candidate[key] else candidate
       continue unless string
-      score = scorer.score(string, query, prepQuery, bAllowErrors, fuzzyWindow)
+      score = scorer.score(string, query, prepQuery, bAllowErrors)
       if score > 0
         scoredCandidates.push({candidate, score})
         break unless --spotLeft

--- a/src/filter.coffee
+++ b/src/filter.coffee
@@ -22,11 +22,6 @@ module.exports = (candidates, query, {key, maxResults, maxInners, allowErrors, l
     # or allow only some characters to be optional, for example: space and space like characters
     coreQuery = if allowErrorsInQuery then query else scorer.coreChars(query)
     coreQuery_lw = coreQuery.toLowerCase()
-
-    #get "file.ext" from "folder/file.ext"
-    pos = query.indexOf(PathSeparator)
-    baseQuery = if pos > -1 then query.substring(pos) else query
-    baseQuery_lw = baseQuery.toLowerCase()
     query_lw = query.toLowerCase()
 
     if(not legacy)
@@ -36,13 +31,13 @@ module.exports = (candidates, query, {key, maxResults, maxInners, allowErrors, l
         string_lw = string.toLowerCase()
         continue unless allowErrorsInQuery or scorer.isMatch(string_lw, coreQuery_lw)
         score = scorer.score(string, query, string_lw, query_lw)
-        score = scorer.basenameScore(string, baseQuery, score, string_lw, baseQuery_lw)
+        score = scorer.basenameScore(string, query, score, string_lw, query_lw)
         if score > 0
           scoredCandidates.push({candidate, score})
           break unless --spotLeft
 
     else
-      queryHasSlashes = pos > -1
+      queryHasSlashes = query.indexOf(PathSeparator)> -1
       for candidate in candidates
         string = if key? then candidate[key] else candidate
         continue unless string

--- a/src/filter.coffee
+++ b/src/filter.coffee
@@ -6,16 +6,16 @@ sortCandidates = (a, b) -> b.score - a.score
 PathSeparator = require('path').sep
 
 module.exports = (candidates, query, {key, maxResults, maxInners, allowErrors, legacy }={}) ->
-
   scoredCandidates = []
-  spotLeft = if maxInners? and  maxInners> 0 then maxInners else candidates.length
+  spotLeft = if maxInners? and maxInners > 0 then maxInners else candidates.length
 
   bAllowErrors = !!allowErrors
+  bKey = key?
   prepQuery = scorer.prepQuery(query)
 
   if(not legacy)
     for candidate in candidates
-      string = if key? then candidate[key] else candidate
+      string = if bKey then candidate[key] else candidate
       continue unless string
       score = scorer.score(string, query, prepQuery, bAllowErrors)
       if score > 0

--- a/src/fuzzaldrin.coffee
+++ b/src/fuzzaldrin.coffee
@@ -13,16 +13,17 @@ module.exports =
     return 0 unless string
     return 0 unless query
 
+    string_lw = string.toLowerCase()
     coreQuery = scorer.coreChars(query)
-    return 0 unless allowErrors or scorer.isMatch(string,coreQuery)
+    return [] unless allowErrors or scorer.isMatch(string_lw,coreQuery.toLowerCase())
 
     #get "file.ext" from "folder/file.ext"
     pos = query.indexOf(PathSeparator)
     baseQuery = if pos > -1 then query.substring(pos) else query
 
     if not legacy
-      score = scorer.score(string, query)
-      score = scorer.basenameScore(string, baseQuery, score)
+      score = scorer.score(string, query, string_lw, query.toLowerCase())
+      score = scorer.basenameScore(string, baseQuery, score , string_lw, baseQuery.toLowerCase())
     else
       queryHasSlashes = pos > -1
       score = legacy_scorer.score(string, coreQuery, queryHasSlashes)
@@ -36,8 +37,9 @@ module.exports =
     return [] unless query
     return [0...string.length] if string is query
 
-    coreQuery = scorer.coreChars(query)
-    return [] unless allowErrors or scorer.isMatch(string,coreQuery)
+    string_lw = string.toLowerCase()
+    coreQuery_lw = scorer.coreChars(query).toLowerCase()
+    return [] unless allowErrors or scorer.isMatch(string_lw,coreQuery_lw)
 
     #get "file.ext" from "folder/file.ext"
     pos = query.indexOf(PathSeparator)

--- a/src/fuzzaldrin.coffee
+++ b/src/fuzzaldrin.coffee
@@ -8,9 +8,10 @@ module.exports =
   filter: (candidates, query, options) ->
     filter(candidates, query, options)
 
-  score: (string, query) ->
+  score: (string, query, {allowErrors}={}) ->
     return 0 unless string
     return 0 unless query
+    return 0 unless !!allowErrors or scorer.isMatch(string,query)
 
     #get "file.ext" from "folder/file.ext"
     pos = query.indexOf(PathSeparator)

--- a/src/fuzzaldrin.coffee
+++ b/src/fuzzaldrin.coffee
@@ -3,22 +3,22 @@ filter = require './filter'
 matcher = require './matcher'
 
 PathSeparator = require('path').sep
-SpaceRegex = /\ /g
+#SpaceRegex = /\ /g
 
 module.exports =
   filter: (candidates, query, options) ->
     if query
       queryHasSlashes = query.indexOf(PathSeparator) isnt -1
-      query = query.replace(SpaceRegex, '')
+      #query = query.replace(SpaceRegex, '')
     filter(candidates, query, queryHasSlashes, options)
 
   score: (string, query) ->
     return 0 unless string
     return 0 unless query
-    return 2 if string is query
+    #return 2 if string is query
 
     queryHasSlashes = query.indexOf(PathSeparator) isnt -1
-    query = query.replace(SpaceRegex, '')
+    #query = query.replace(SpaceRegex, '')
     score = scorer.score(string, query)
     score = scorer.basenameScore(string, query, score) unless queryHasSlashes
     score
@@ -29,7 +29,7 @@ module.exports =
     return [0...string.length] if string is query
 
     queryHasSlashes = query.indexOf(PathSeparator) isnt -1
-    query = query.replace(SpaceRegex, '')
+    #query = query.replace(SpaceRegex, '')
     matches = matcher.match(string, query)
     unless queryHasSlashes
       baseMatches = matcher.basenameMatch(string, query)

--- a/src/fuzzaldrin.coffee
+++ b/src/fuzzaldrin.coffee
@@ -1,4 +1,5 @@
 scorer = require './scorer'
+legacy_scorer = require './legacy'
 filter = require './filter'
 matcher = require './matcher'
 
@@ -8,7 +9,7 @@ module.exports =
   filter: (candidates, query, options) ->
     filter(candidates, query, options)
 
-  score: (string, query, {allowErrors}={}) ->
+  score: (string, query, {allowErrors, legacy}={}) ->
     return 0 unless string
     return 0 unless query
     return 0 unless allowErrors or scorer.isMatch(string,query)
@@ -17,8 +18,14 @@ module.exports =
     pos = query.indexOf(PathSeparator)
     baseQuery = if pos > -1 then query.substring(pos) else query
 
-    score = scorer.score(string, query)
-    score = scorer.basenameScore(string, baseQuery, score)
+    if not legacy
+      score = scorer.score(string, query)
+      score = scorer.basenameScore(string, baseQuery, score)
+    else
+      queryHasSlashes = pos > -1
+      score = legacy_scorer.score(string, coreQuery, queryHasSlashes)
+      unless queryHasSlashes
+        score = legacy_scorer.basenameScore(string, coreQuery, score)
 
     score
 

--- a/src/fuzzaldrin.coffee
+++ b/src/fuzzaldrin.coffee
@@ -17,15 +17,12 @@ module.exports =
     coreQuery = scorer.coreChars(query)
     return [] unless allowErrors or scorer.isMatch(string_lw,coreQuery.toLowerCase())
 
-    #get "file.ext" from "folder/file.ext"
-    pos = query.indexOf(PathSeparator)
-    baseQuery = if pos > -1 then query.substring(pos) else query
-
+    query_lw = query.toLowerCase()
     if not legacy
-      score = scorer.score(string, query, string_lw, query.toLowerCase())
-      score = scorer.basenameScore(string, baseQuery, score , string_lw, baseQuery.toLowerCase())
+      score = scorer.score(string, query, string_lw, query_lw)
+      score = scorer.basenameScore(string, query, score , string_lw, query_lw)
     else
-      queryHasSlashes = pos > -1
+      queryHasSlashes =  query.indexOf(PathSeparator)> -1
       score = legacy_scorer.score(string, coreQuery, queryHasSlashes)
       unless queryHasSlashes
         score = legacy_scorer.basenameScore(string, coreQuery, score)

--- a/src/fuzzaldrin.coffee
+++ b/src/fuzzaldrin.coffee
@@ -11,7 +11,7 @@ module.exports =
   score: (string, query, {allowErrors}={}) ->
     return 0 unless string
     return 0 unless query
-    return 0 unless !!allowErrors or scorer.isMatch(string,query)
+    return 0 unless allowErrors or scorer.isMatch(string,query)
 
     #get "file.ext" from "folder/file.ext"
     pos = query.indexOf(PathSeparator)
@@ -26,8 +26,7 @@ module.exports =
     return [] unless string
     return [] unless query
     return [0...string.length] if string is query
-
-    return [] unless !!allowErrors or scorer.isMatch(string,query)
+    return [] unless allowErrors or scorer.isMatch(string,query)
 
     #get "file.ext" from "folder/file.ext"
     pos = query.indexOf(PathSeparator)

--- a/src/fuzzaldrin.coffee
+++ b/src/fuzzaldrin.coffee
@@ -11,13 +11,21 @@ module.exports =
     return [] unless query?.length and candidates?.length
     filter(candidates, query, options)
 
-  score: (string, query, prepQuery = scorer.prepQuery(query), {allowErrors, legacy, fuzzyWindow}={}) ->
+  #
+  # While the API is backward compatible,
+  # the following pattern is recommended for speed.
+  #
+  # query = ...
+  # prepared = fuzzaldrin.prepQuery(query)
+  # for candidate in candidates
+  #    score = fuzzaldrin.score(candidate, query, prepared)
+  #
+
+  score: (string, query, prepQuery = scorer.prepQuery(query), {allowErrors, legacy}={}) ->
     return 0 unless string?.length and query?.length
 
-    fuzzyWindow ?= scorer.defaultSearchWindow
-
     if not legacy
-      score = scorer.score(string, query, prepQuery, !!allowErrors, fuzzyWindow)
+      score = scorer.score(string, query, prepQuery, !!allowErrors)
     else
       queryHasSlashes = prepQuery.depth > 0
       coreQuery = prepQuery.core

--- a/src/fuzzaldrin.coffee
+++ b/src/fuzzaldrin.coffee
@@ -28,7 +28,7 @@ module.exports =
     matches = matcher.match(string, query)
     unless queryHasSlashes
       baseMatches = matcher.basenameMatch(string, query)
-      # Combine the results, removing dupicate indexes
+      # Combine the results, removing duplicate indexes
       matches = matches.concat(baseMatches).sort (a, b) -> a - b
       seen = null
       index = 0

--- a/src/fuzzaldrin.coffee
+++ b/src/fuzzaldrin.coffee
@@ -7,6 +7,7 @@ PathSeparator = require('path').sep
 
 module.exports =
   filter: (candidates, query, options) ->
+    return [] unless query and query.length and candidates and candidates.length
     filter(candidates, query, options)
 
   score: (string, query, {allowErrors, legacy}={}) ->

--- a/src/fuzzaldrin.coffee
+++ b/src/fuzzaldrin.coffee
@@ -3,22 +3,18 @@ filter = require './filter'
 matcher = require './matcher'
 
 PathSeparator = require('path').sep
-#SpaceRegex = /\ /g
 
 module.exports =
   filter: (candidates, query, options) ->
     if query
       queryHasSlashes = query.indexOf(PathSeparator) isnt -1
-      #query = query.replace(SpaceRegex, '')
     filter(candidates, query, queryHasSlashes, options)
 
   score: (string, query) ->
     return 0 unless string
     return 0 unless query
-    #return 2 if string is query
 
     queryHasSlashes = query.indexOf(PathSeparator) isnt -1
-    #query = query.replace(SpaceRegex, '')
     score = scorer.score(string, query)
     score = scorer.basenameScore(string, query, score) unless queryHasSlashes
     score
@@ -29,7 +25,6 @@ module.exports =
     return [0...string.length] if string is query
 
     queryHasSlashes = query.indexOf(PathSeparator) isnt -1
-    #query = query.replace(SpaceRegex, '')
     matches = matcher.match(string, query)
     unless queryHasSlashes
       baseMatches = matcher.basenameMatch(string, query)

--- a/src/fuzzaldrin.coffee
+++ b/src/fuzzaldrin.coffee
@@ -12,7 +12,9 @@ module.exports =
   score: (string, query, {allowErrors, legacy}={}) ->
     return 0 unless string
     return 0 unless query
-    return 0 unless allowErrors or scorer.isMatch(string,query)
+
+    coreQuery = scorer.coreChars(query)
+    return 0 unless allowErrors or scorer.isMatch(string,coreQuery)
 
     #get "file.ext" from "folder/file.ext"
     pos = query.indexOf(PathSeparator)
@@ -33,7 +35,9 @@ module.exports =
     return [] unless string
     return [] unless query
     return [0...string.length] if string is query
-    return [] unless allowErrors or scorer.isMatch(string,query)
+
+    coreQuery = scorer.coreChars(query)
+    return [] unless allowErrors or scorer.isMatch(string,coreQuery)
 
     #get "file.ext" from "folder/file.ext"
     pos = query.indexOf(PathSeparator)

--- a/src/legacy.coffee
+++ b/src/legacy.coffee
@@ -89,7 +89,7 @@ queryIsLastPathSegment = (string, query) ->
     string.lastIndexOf(query) is string.length - query.length
 
 
-exports.match = (string, query, stringOffset=0) ->
+exports.match = (string, query, stringOffset = 0) ->
   return [stringOffset...stringOffset + string.length] if string is query
 
   queryLength = query.length

--- a/src/legacy.coffee
+++ b/src/legacy.coffee
@@ -1,0 +1,118 @@
+# Original ported from:
+#
+# string_score.js: String Scoring Algorithm 0.1.10
+#
+# http://joshaven.com/string_score
+# https://github.com/joshaven/string_score
+#
+# Copyright (C) 2009-2011 Joshaven Potter <yourtech@gmail.com>
+# Special thanks to all of the contributors listed here https://github.com/joshaven/string_score
+# MIT license: http://www.opensource.org/licenses/mit-license.php
+#
+# Date: Tue Mar 1 2011
+
+PathSeparator = require('path').sep
+
+exports.basenameScore = (string, query, score) ->
+  index = string.length - 1
+  index-- while string[index] is PathSeparator # Skip trailing slashes
+  slashCount = 0
+  lastCharacter = index
+  base = null
+  while index >= 0
+    if string[index] is PathSeparator
+      slashCount++
+      base ?= string.substring(index + 1, lastCharacter + 1)
+    else if index is 0
+      if lastCharacter < string.length - 1
+        base ?= string.substring(0, lastCharacter + 1)
+      else
+        base ?= string
+    index--
+
+  # Basename matches count for more.
+  if base is string
+    score *= 2
+  else if base
+    score += exports.score(base, query)
+
+  # Shallow files are scored higher
+  segmentCount = slashCount + 1
+  depth = Math.max(1, 10 - segmentCount)
+  score *= depth * 0.01
+  score
+
+exports.score = (string, query) ->
+  return 1 if string is query
+
+  # Return a perfect score if the file name itself matches the query.
+  return 1 if queryIsLastPathSegment(string, query)
+
+  totalCharacterScore = 0
+  queryLength = query.length
+  stringLength = string.length
+
+  indexInQuery = 0
+  indexInString = 0
+
+  while indexInQuery < queryLength
+    character = query[indexInQuery++]
+    lowerCaseIndex = string.indexOf(character.toLowerCase())
+    upperCaseIndex = string.indexOf(character.toUpperCase())
+    minIndex = Math.min(lowerCaseIndex, upperCaseIndex)
+    minIndex = Math.max(lowerCaseIndex, upperCaseIndex) if minIndex is -1
+    indexInString = minIndex
+    return 0 if indexInString is -1
+
+    characterScore = 0.1
+
+    # Same case bonus.
+    characterScore += 0.1 if string[indexInString] is character
+
+    if indexInString is 0 or string[indexInString - 1] is PathSeparator
+      # Start of string bonus
+      characterScore += 0.8
+    else if string[indexInString - 1] in ['-', '_', ' ']
+      # Start of word bonus
+      characterScore += 0.7
+
+    # Trim string to after current abbreviation match
+    string = string.substring(indexInString + 1, stringLength)
+
+    totalCharacterScore += characterScore
+
+  queryScore = totalCharacterScore / queryLength
+  ((queryScore * (queryLength / stringLength)) + queryScore) / 2
+
+queryIsLastPathSegment = (string, query) ->
+  if string[string.length - query.length - 1] is PathSeparator
+    string.lastIndexOf(query) is string.length - query.length
+
+
+exports.match = (string, query, stringOffset=0) ->
+  return [stringOffset...stringOffset + string.length] if string is query
+
+  queryLength = query.length
+  stringLength = string.length
+
+  indexInQuery = 0
+  indexInString = 0
+
+  matches = []
+
+  while indexInQuery < queryLength
+    character = query[indexInQuery++]
+    lowerCaseIndex = string.indexOf(character.toLowerCase())
+    upperCaseIndex = string.indexOf(character.toUpperCase())
+    minIndex = Math.min(lowerCaseIndex, upperCaseIndex)
+    minIndex = Math.max(lowerCaseIndex, upperCaseIndex) if minIndex is -1
+    indexInString = minIndex
+    return [] if indexInString is -1
+
+    matches.push(stringOffset + indexInString)
+
+    # Trim string to after current abbreviation match
+    stringOffset += indexInString + 1
+    string = string.substring(indexInString + 1, stringLength)
+
+  matches

--- a/src/matcher.coffee
+++ b/src/matcher.coffee
@@ -6,22 +6,31 @@ PathSeparator = require('path').sep
 scorer = require './scorer'
 
 
-exports.basenameMatch = (string, query) ->
+exports.basenameMatch = (subject, query) ->
 
   # Skip trailing slashes
-  end = string.length - 1
-  end-- while string[end] is PathSeparator
+  end = subject.length - 1
+  end-- while subject[end] is PathSeparator
 
-  # Get position of basePath of string. If no PathSeparator, no base path exist.
-  basePos = string.lastIndexOf(PathSeparator, end)
+  # Get position of basePath of subject. If no PathSeparator, no base path exist.
+  basePos = subject.lastIndexOf(PathSeparator, end)
+
+  # Get the number of folder in query
+  qdepth = scorer.countDir(query, query.length)
+
+  # Get that many folder from subject
+  while(basePos > -1 && qdepth--)
+    basePos = subject.lastIndexOf(PathSeparator, basePos-1)
+
+  #consumed whole subject ?
   return [] if (basePos == -1)
 
   # Get basePath match
-  exports.match(string.substring(basePos + 1, end + 1), query, basePos+1)
+  exports.match(subject[basePos + 1 ... end + 1], query, basePos+1)
 
 
-exports.match = (string, query, stringOffset=0) ->
-  return scorer.align(string, query, stringOffset)
+exports.match = (subject, query, stringOffset=0) ->
+  return scorer.align(subject, query, stringOffset)
 
 
 #

--- a/src/matcher.coffee
+++ b/src/matcher.coffee
@@ -24,37 +24,6 @@ exports.match = (string, query, stringOffset=0) ->
   return scorer.align(string, query, stringOffset)
 
 
-# Fast but greedy algorithm, IE it report the first occurrence of char
-# even if a latter occurrence will score more
-exports.fastMatch = (string, query, stringOffset=0) ->
-  return [stringOffset...stringOffset + string.length] if string is query
-
-  queryLength = query.length
-  stringLength = string.length
-
-  indexInQuery = 0
-  indexInString = 0
-
-  matches = []
-
-  while indexInQuery < queryLength
-    character = query[indexInQuery++]
-    lowerCaseIndex = string.indexOf(character.toLowerCase())
-    upperCaseIndex = string.indexOf(character.toUpperCase())
-    minIndex = Math.min(lowerCaseIndex, upperCaseIndex)
-    minIndex = Math.max(lowerCaseIndex, upperCaseIndex) if minIndex is -1
-    indexInString = minIndex
-    return [] if indexInString is -1
-
-    matches.push(stringOffset + indexInString)
-
-    # Trim string to after current abbreviation match
-    stringOffset += indexInString + 1
-    string = string.substring(indexInString + 1, stringLength)
-
-  matches
-
-
 #
 # Combine two matches result and remove duplicate
 # (Assume sequences are sorted, matches are sorted by construction.)

--- a/src/matcher.coffee
+++ b/src/matcher.coffee
@@ -12,25 +12,22 @@ exports.basenameMatch = (subject, query) ->
   end = subject.length - 1
   end-- while subject[end] is PathSeparator
 
-  # Get position of basePath of subject. If no PathSeparator, no base path exist.
+  # Get position of basePath of subject.
   basePos = subject.lastIndexOf(PathSeparator, end)
 
-  # Get the number of folder in query
-  qdepth = scorer.countDir(query, query.length)
-
-  # Get that many folder from subject
-  while(basePos > -1 && qdepth--)
-    basePos = subject.lastIndexOf(PathSeparator, basePos-1)
-
-  #consumed whole subject ?
+  #If no PathSeparator, no base path exist.
   return [] if (basePos == -1)
 
+  # Get the number of folder in query
+  depth = scorer.countDir(query, query.length)
+
+  # Get that many folder from subject
+  while(depth-- > 0)
+    basePos = subject.lastIndexOf(PathSeparator, basePos - 1)
+    return [] if (basePos == -1) #consumed whole subject ?
+
   # Get basePath match
-  exports.match(subject[basePos + 1 ... end + 1], query, basePos+1)
-
-
-exports.match = (subject, query, stringOffset=0) ->
-  return scorer.align(subject, query, stringOffset)
+  exports.match(subject[basePos + 1 ... end + 1], query, basePos + 1)
 
 
 #
@@ -65,3 +62,143 @@ exports.mergeMatches = (a, b) ->
     out.push b[j++]
 
   return out
+
+#----------------------------------------------------------------------
+
+#
+# Align sequence (used for fuzzaldrin.match)
+# Return position of subject characters that match query.
+#
+# Follow closely scorer.doScore.
+# Except at each step we record what triggered the best score.
+# Then we trace back to output matched characters.
+
+exports.match = (subject, query, offset = 0, fuzzyWindow = scorer.defaultSearchWindow) ->
+
+  m = subject.length
+  n = query.length
+
+  #max string size for O(m*n) best match search
+  m = fuzzyWindow if m > fuzzyWindow
+  n = fuzzyWindow if n > fuzzyWindow
+
+  subject_lw = subject.toLowerCase()
+  query_lw = query.toLowerCase()
+
+  #this is like the consecutive bonus, but for scattered camelCase initials
+  acro_score = scorer.scoreAcronyms(subject, subject_lw, query, query_lw).score
+
+  #Init
+  vRow = new Array(n)
+  cscRow = new Array(n)
+
+  vmax = 0
+  imax = -1
+  jmax = -1
+
+  # Directions constants
+  STOP = 0
+  UP = 1
+  LEFT = 2
+  DIAGONAL = 3
+
+  #Traceback matrix
+  trace = new Array(m * n)
+  pos = -1
+
+  #Fill with 0
+  j = -1
+  while ++j < n
+    vRow[j] = 0
+    cscRow[j] = 0
+
+  i = -1 #0..m-1
+  while ++i < m #foreach char si of subject
+
+    v = 0
+    v_diag = 0
+    csc_diag = 0
+    si_lw = subject_lw[i]
+
+    j = -1 #0..n-1
+    while ++j < n #foreach char qj of query
+
+      #reset score
+      csc_score = 0
+      align = 0
+
+      #Compute a tentative match
+      if ( query_lw[j] == si_lw )
+
+        # Forward search for a sequence of consecutive char
+        csc_score = if csc_diag > 0  then csc_diag else scorer.scoreConsecutives(subject, subject_lw, query, query_lw,
+          i, j)
+
+        # Determine bonus for matching A[i] with B[j]
+        align = v_diag + scorer.scoreCharacter(subject, subject_lw, query, i, j, acro_score, csc_score)
+
+      #Prepare next sequence & match score.
+      v_diag = vRow[j]
+      csc_diag = cscRow[j]
+
+      #Compare the score of making a match, a gap in Query (A), or a gap in Subject (B)
+
+      gapA = v_diag
+      gapB = v
+      gap = if(gapA > gapB) then gapA else gapB
+
+      if(align > gap)
+        vRow[j] = v = align
+        cscRow[j] = csc_score
+      else
+        vRow[j] = v = gap
+        cscRow[j] = 0 #If we do not use this character reset consecutive sequence.
+
+      # what triggered the best score ?
+      #In case of equality, taking gapA get us closer to the start of the string.
+      pos++ #pos = i * n + j
+      switch v
+        when 0
+          trace[pos] = STOP
+        when gapA
+          trace[pos] = UP
+        when gapB
+          trace[pos] = LEFT
+        when align
+          trace[pos] = DIAGONAL
+          #Record best score
+          if v > vmax
+            vmax = v
+            imax = i
+            jmax = j
+
+
+  # -------------------
+  # Go back in the trace matrix from imax, jmax
+  # and collect diagonals
+
+  i = imax
+  j = jmax
+  pos = i * n + j
+  backtrack = true
+  matches = []
+
+  while backtrack and i >= 0 and j >= 0
+    switch trace[pos]
+      when UP
+        i--
+        pos -= n
+      when LEFT
+        j--
+        pos--
+      when DIAGONAL
+        matches.push(i + offset)
+        j--
+        i--
+        pos -= n + 1
+      else
+        backtrack = false
+
+  matches.reverse()
+  return matches
+

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -251,7 +251,6 @@ scoreSize = (n, m) ->
 #
 
 exports.scorePattern = scorePattern = (count, len, sameCase, start, end) ->
-  return 1 + 2 * sameCase if count is 1
 
   sz = count
 

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -307,11 +307,11 @@ exports.basenameScore = (string, query, score) ->
   return score if (basePos == -1)
 
   # Get baseScore bonus
-  baseScore = Math.max(score, exports.score(string.substring(basePos + 1, end + 1), query))
+  baseScore = exports.score(string.substring(basePos + 1, end + 1), query)
 
   # We'll merge some of that bonus with full path score.
   # Importance of bonus fade with directory depth until it reach 50/50
-  alpha = 0.5 + 2.5 / ( 5.0 + countDir(string, end + 1) )
+  alpha = 2.5 / ( 5.0 + countDir(string, end + 1) )
   score = alpha * baseScore + (1 - alpha) * score
 
   return score

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -89,7 +89,7 @@ exports.isMatch = isMatch = (subject, query_lw, query_up) ->
     qj_lw = query_lw[j]
     qj_up = query_up[j]
 
-    while( ++i < m)
+    while ++i < m
       si = subject[i]
       break if si == qj_lw or si == qj_up
 
@@ -381,7 +381,9 @@ emptyAcronymResult = new AcronymResult(0, 0.1, 0)
 exports.scoreAcronyms = scoreAcronyms = (subject, subject_lw, query, query_lw) ->
   m = subject.length
   n = query.length
-  return emptyAcronymResult unless m and n
+
+  #a single char is not an acronym
+  return emptyAcronymResult unless m > 1 and n > 1
 
   count = 0
   pos = 0
@@ -398,11 +400,8 @@ exports.scoreAcronyms = scoreAcronyms = (subject, subject_lw, query, query_lw) -
     while ++i < m
 
       #test if subject match
-      if(qj_lw == subject_lw[i])
-
-        # subject match.. test if we have an acronym
-        # if so, record result & break to next char of query.
-        if isWordStart(i, subject, subject_lw)
+      # Only record match that are also start-of-word.
+      if qj_lw == subject_lw[i] and isWordStart(i, subject, subject_lw)
           sameCase++ if ( query[j] == subject[i] )
           pos += i
           count++

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -175,8 +175,17 @@ isMatch = (query, subject) ->
 exports.basenameScore = (string, query, score) ->
 
   return 0 if score == 0
-  index = string.length - 1
-  index-- while string[index] is PathSeparator # Skip trailing slashes
+  end = string.length - 1
+  end-- while string[end] is PathSeparator # Skip trailing slashes
+
+  basePos = string.lastIndexOf(PathSeparator, end)
+  baseScore = if (basePos == -1) then score else Math.max(score, exports.score(string.substring(basePos + 1, end+1), query))
+  score = 0.25*score + 0.75*baseScore
+
+  score
+
+ ###
+
   slashCount = 0
   baseScore = 0
   lastCharacter = index
@@ -192,14 +201,12 @@ exports.basenameScore = (string, query, score) ->
         base ?= string
     index--
 
-  # Basename matches count for more, if improvement.
-  if base is string
-    baseScore = score
-  else if base
-    baseScore = Math.max(score, exports.score(base, query))
+   # Shallow files are scored higher
+   score += baseScore*( 3.0 + 3.0/(3.0+slashCount) )
 
-  # Shallow files are scored higher
-  score += baseScore*( 3.0 + 3.0/(3.0+slashCount) )
+ ###
 
-  score
+
+
+
 

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -7,9 +7,6 @@
 #
 # Copyright (C) 2015 Jean Christophe Roy and contributors
 # MIT License: http://opensource.org/licenses/MIT
-#
-# Previous version of scorer used string_score from Joshaven Potter
-# https://github.com/joshaven/string_score/
 
 
 wm = 100 # base score of making a match

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -145,7 +145,7 @@ exports.score = score = (subject, query) ->
 
   #----------------------------
   # Individual chars
-  # (Smith Waterman Gotoh algorithm)
+  # (Smith Waterman algorithm)
 
   #Init
   vRow = new Array(n)

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -54,6 +54,18 @@ exports.coreChars = coreChars = (query) ->
   return query.replace(opt_char_re, '')
 
 #
+# Search window
+# string_match compute the score using first occurrence of character.
+# we'll consider all occurrences, but limit this search of the best occurrence to
+# a window at the start of the string. This mostly concern deeply nested path
+# and they receive a special treatment for baseName.
+#
+# Exact match will still continue to search full string.
+#
+
+fuzzyMaxlen = 64
+
+#
 # isMatch:
 # Are all characters of query in subject, in proper order
 #
@@ -143,11 +155,16 @@ exports.score = score = (subject, query) ->
   m = query.length + 1
   n = subject.length + 1
 
+  #haystack size penalty
+  sz = 4 * tau / (4 * tau + n)
+
+  #max string size
+  n = fuzzyMaxlen + 1 if n > fuzzyMaxlen
+
+  #precompute lowercase
   subject_lw = subject.toLowerCase()
   query_lw = query.toLowerCase()
 
-  #haystack size penalty
-  sz = 4 * tau / (4 * tau + n)
 
   #----------------------------
   # Exact Match
@@ -337,6 +354,9 @@ abbrPrefix = (query, query_lw, subject, subject_lw) ->
   n = subject.length
   return abbrInfo0 unless m and n
 
+  #Abbreviation is a fuzzy match
+  n = fuzzyMaxlen if n > fuzzyMaxlen
+
   count = 0
   pos = 0
   sameCase = 0
@@ -401,6 +421,9 @@ abbrPrefix = (query, query_lw, subject, subject_lw) ->
 exports.align = (subject, query, offset = 0) ->
   m = query.length + 1
   n = subject.length + 1
+
+  #max string size
+  n = fuzzyMaxlen + 1 if n > fuzzyMaxlen
 
   subject_lw = subject.toLowerCase()
   query_lw = query.toLowerCase()

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -147,7 +147,7 @@ exports.score = score = (subject, query, ignore) ->
     while ++j < n
       #foreach char of subject
 
-      # exact the options
+      # score the options
       gapA = gapArow[j] = Math.max(gapArow[j] + we, vrow[j] + wo)
       gapB = Math.max(gapB + we, vrow[j - 1] + wo)
       align = if ( query_lw[i - 1] == subject_lw[j - 1] ) then vd + scoreMatchingChar(query, subject, i - 1, j - 1) else 0
@@ -156,7 +156,7 @@ exports.score = score = (subject, query, ignore) ->
       #Get the best option (align set the lower-bound to 0)
       v = vrow[j] = Math.max(align, gapA, gapB)
 
-      #Record best exact
+      #Record best score
       if v > vmax
         vmax = v
 

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -47,8 +47,13 @@ sep_map = do ->
 # Optional chars
 # Some characters of query char MUST be in subject,
 # Others COULD be there or not, better Score if they are, but don't block isMatch.
+#
+# Interchangeable are,
+# - word separator,
+# - backward/forward slashes (to support multiple OS and php namespace)
+# - colon (to support Rails  namespace)
 
-opt_char_re = /[ _\-]/g
+opt_char_re = /[ _\-:\/\\]/g
 
 exports.coreChars = coreChars = (query) ->
   return query.replace(opt_char_re, '')

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -28,272 +28,42 @@ wex = 1000 # bonus per character of an exact match. If exact coincide with prefi
 #
 # Fading function
 #
-# f(x) = tau / ( tau + x) will be used for bonus that fade with position
-# it'll also be used to penalize larger haystack.
-#
-# f(0) = 1, f(half_score) = 0.5
-# tau / ( tau + half_score) = 0.5
-# tau / ( tau + tau) = 0.5 => tau = half_score
+# f(x) = tau / ( tau + x) will be used for bonus that fade with position and to to penalize larger haystack.
+# tau is the value of x, for which f(x) = 0.5*f(0) = 0.5
 
 tau = 15
 
-
-#Note: separator are likely to trigger both a
-# "acronym" and "proper case" bonus in addition of their own bonus.
+#
+# Separators
+#
 
 separators = ' .-_/\\'
 PathSeparator = require('path').sep
 
-#
-# Build a hashmap of separator
-#
+#Save above separator in a dictionary for quick lookup
+sep_map = do ->
 
-separator_map = ->
-  sep_map = {}
+  map = {}
   k = -1
-  while ++k < separators.length
-    sep_map[separators[k]] = k
+  len = separators.length
+  while ++k < len
+    map[separators[k]] = k
 
-  return sep_map
-
-# save hashmap in current closure
-sep_map = separator_map()
+  map
 
 
 # Optional chars
 # Some characters of query char MUST be in subject,
-# Others COULD be there or not, better Score if they are, but not blocking isMatch.
-#
-# For example:
-# - space can be skipped in favor of a slash.
-# - space like separator like in slug "-" "_" " "
-#
+# Others COULD be there or not, better Score if they are, but don't block isMatch.
 
 opt_char_re = /[ _\-]/g
-
-#
-# Main scoring algorithm
-#
-
-exports.score = score = (subject, query) ->
-  m = query.length + 1
-  n = subject.length + 1
-
-  subject_lw = subject.toLowerCase()
-  query_lw = query.toLowerCase()
-
-  #haystack size penalty
-  sz = 4*tau / (4*tau + n)
-
-  #----------------------------
-  # Exact Match
-  # => bypass
-
-  if ( p = subject_lw.indexOf(query_lw)) > -1
-
-    #bonus per consecutive char grow with number of consecutive
-    #so this need to be squared to stay on top.
-    base = wex * m *m
-
-    #base bonus + position decay
-    exact = base * (1.0 + tau / (tau + p))
-
-    #sustring happens right after a separator (prefix)
-    if (p == 0 or subject[p - 1] of sep_map)
-      exact += 4 * base
-
-    # last position, the +1s cancel out
-    # for both the "length=<last index>+1" and the buffer=length+1
-    lpos = n - m
-
-    #sustring happens right before a separator (suffix)
-    if (p == lpos or subject[p + 1] of sep_map)
-      exact += base
-
-    if(subject.indexOf(query) > -1)
-      #substring is ExactCase
-      exact += 2*base
-
-    else
-      #test for camelCase
-      camel = camelPrefix(subject, subject_lw, query, query_lw)
-      camelCount =  camel[2]
-      if camelCount > 1 #don't count a single capital as camel
-        camelBonus =  camel[0]
-        exact += 1.5 * wex * camelBonus * camelBonus * (1.0 + tau / (tau + camel[1]))
-
-    return exact * sz
-
-  #----------------------------
-  # Abbreviations sequence
-
-  # for example, if we type "surl" to search StatusUrl
-  # this will recognize and boost "su" as CamelCase sequence
-  # then "surl" will be passed to next scoring step.
-
-  #test for camelCase
-  camel = camelPrefix(subject, subject_lw, query, query_lw)
-  camelCount =  camel[2]
-  exact = 0
-  if camelCount > 1
-    camelBonus =  camel[0]
-    exact += 5 * wex * camelBonus * camelBonus * (1.0 + tau / (tau + camel[1]))
-
-    #Whole query is camelCase abbreviation ? then => bypass
-    if( camelCount == query.length)
-      return exact * sz
-
-  #----------------------------
-  # Individual chars
-  # (Smith Waterman algorithm)
-
-  #Init
-  vRow = new Array(n)
-  seqRow = new Array(n)
-  vmax = 0
-
-  #Fill with 0
-  j = -1
-  while ++j < n
-    vRow[j] = 0
-    seqRow[j] = 0
-
-  i = 0 #1..m-1
-  while ++i < m     #foreach char of query
-
-    v_diag = vRow[0]
-    seq_diag = seqRow[0]
-
-    j = 0 #1..n-1
-    while ++j < n   #foreach char of subject
-
-
-      #Compute a tentative match
-      if ( query_lw[i - 1] == subject_lw[j - 1] )
-
-        #forward search for a sequence of consecutive char (will apply some bonus for exact casing or exact match)
-        csc = if seq_diag == 0 then countConsecutive(query, query_lw, subject, subject_lw, i-1 , j-1 ) else  seq_diag
-        seq_diag = seqRow[j]
-        seqRow[j] = csc
-
-        #determine bonus for matching A[i-1] with B[j-1]
-        align =  v_diag + csc*scoreMatchingChar(query, subject, i - 1, j - 1, camelBonus)
-
-      else
-        seq_diag = seqRow[j]
-        seqRow[j] = 0
-        align = 0
-
-      #Compare the score of making a match, a gap in Query (A), or a gap in Subject (B)
-      v_diag = vRow[j]
-      v = vRow[j] = Math.max(align, vRow[j] + we, vRow[j - 1] + we)
-
-      #Record the best score so far
-      if v > vmax
-        vmax = v
-
-
-  return (vmax + exact) * sz
-
-#
-# Compute the bonuses for two chars that are confirmed to matches in a case-insensitive way
-#
-
-scoreMatchingChar = (query, subject, i, j, camelBonus) ->
-
-  qi = query[i]
-  sj = subject[j]
-
-  #Proper casing bonus
-  bonus = if qi == sj then wc else 0
-
-  #start of string bonus
-  bonus += Math.floor(wst * tau / (tau  + j))
-
-  #match IS a separator
-  return ws + bonus if qi of sep_map
-
-  #match is FIRST char ( place a virtual token separator before first char of string)
-  return wa + bonus if  j == 0
-
-  #get previous char
-  prev_s = subject[j - 1]
-
-  #match FOLLOW a separator
-  return wa + bonus if ( prev_s of sep_map)
-
-  #match is Capital in camelCase (preceded by lowercase)
-  return (1 + camelBonus) * wa + bonus if (sj == sj.toUpperCase() and prev_s == prev_s.toLowerCase())
-
-  #normal Match, add proper case bonus
-  return wm + bonus
-
-
-#
-# Count the number of camelCase prefix
-# Note that case insensitive character such as space will count as lowercase.
-# So this handle both "CamelCase" and "Title Case"
-
-camelPrefix = (subject, subject_lw, query, query_lw) ->
-
-  m = query_lw.length
-  n = subject_lw.length
-
-  count = 0
-  pos = 0
-  sameCase = 0
-
-  i = -1
-  j = -1
-  k = n - 1
-
-  while ++i < m
-
-    qi_lw = query_lw[i]
-
-    while ++j < n
-
-      sj = subject[j]
-      sj_lw = subject_lw[j]
-
-      #Lowecase, continue
-      if(sj == sj_lw) then continue
-
-      #Subject Uppercase, is it a match ?
-      else if( qi_lw == sj_lw )
-
-        #record position
-        #pos = j if count == 0
-        pos += j
-
-        #Is Query Uppercase too ?
-        qi = query[i]
-        count++
-        sameCase++ if( qi == qi.toUpperCase() )
-
-        break
-
-      #End of subject
-      if j == k then return [count+sameCase, pos / (count + 1), count]
-
-      else
-        # Skipped a CamelCase candidate...
-        # Lower quality of the match by increasing first match pos
-        pos+=3
-
-  #end of query
-  return [count+sameCase, pos / (count + 1), count]
-
-#
-# filer query until we only get required char
-#
 
 exports.coreChars = coreChars = (query) ->
   return query.replace(opt_char_re, '')
 
-
 #
-# yes/no: is all required characters of query in subject, in proper order
+# isMatch:
+# Are all characters of query in subject, in proper order
 #
 
 exports.isMatch = isMatch = (subject, query) ->
@@ -325,32 +95,7 @@ exports.isMatch = isMatch = (subject, query) ->
 
   return true
 
-#
-# Count consecutive
-#
-
-countConsecutive = (query, query_lw, subject, subject_lw, i , j ) ->
-
-  m = query.length
-  dm = query.length - i
-  dn = subject.length - j
-  k = if dm<dn then dm else dn
-
-  sameCase = 0
-
-  f=-1
-  while (++f<k and query_lw[i+f] == subject_lw[j+f])
-    if (query[i+f] == subject[j+f]) then sameCase++
-
-  # exact match bonus (like score IndexOf)
-  if sameCase == m
-    return 5*m
-  if f==m
-    return 2*(f+sameCase)
-  else
-    return f+sameCase
-
-
+#----------------------------------------------------------------------
 
 #
 # Score adjustment for path
@@ -374,12 +119,12 @@ exports.basenameScore = (string, query, fullPathScore) ->
   # Mix start favoring base Path then favor full path as directory depth increase
   # Note that base Path test are more nested than original, so we have to compensate one level of nesting.
 
-  alpha = 0.5 * 2*tau / ( 2*tau + countDir(string, end + 1) )
+  alpha = 0.5 * 2 * tau / ( 2 * tau + countDir(string, end + 1) )
   return  alpha * basePathScore + (1 - alpha) * fullPathScore
 
 #
 # Count number of folder in a path.
-#
+# (skip consecutive slashes)
 
 countDir = (path, end) ->
   return 0 if end < 1
@@ -394,31 +139,253 @@ countDir = (path, end) ->
       while ++i < end and path[i] == PathSeparator
         continue
 
-    else if p == "." and ++i < end and path[i] == "." and ++i < end and path[i] == "/"
-      --count
-
-  # dot behavior:
-  # a) go back one folder in "../"
-  # b) suppress next char: "./" is current folder
-  # c) normal char ".git/"
-
   return count
+
+#----------------------------------------------------------------------
+
+#
+# Main scoring algorithm
+#
+
+exports.score = score = (subject, query) ->
+  m = query.length + 1
+  n = subject.length + 1
+
+  subject_lw = subject.toLowerCase()
+  query_lw = query.toLowerCase()
+
+  #haystack size penalty
+  sz = 4 * tau / (4 * tau + n)
+
+  #----------------------------
+  # Exact Match
+  # => bypass
+
+  if ( p = subject_lw.indexOf(query_lw)) > -1
+
+    #bonus per consecutive char grow with number of consecutive
+    #so this need to be squared to stay on top.
+    base = wex * m * m
+
+    #base bonus + position decay
+    exact = base * (1.0 + tau / (tau + p))
+
+    #sustring happens right after a separator (prefix)
+    if (p == 0 or subject[p - 1] of sep_map)
+      exact += 4 * base
+
+    # last position, the +1s cancel out
+    # for both the "length=<last index>+1" and the buffer=length+1
+    lpos = n - m
+
+    #sustring happens right before a separator (suffix)
+    if (p == lpos or subject[p + 1] of sep_map)
+      exact += base
+
+    if(subject.indexOf(query) > -1)
+      #substring is ExactCase
+      exact += 2 * base
+
+    else
+      #test for camelCase
+      camel = camelPrefix(query, query_lw, subject, subject_lw)
+      camelCount = camel[2]
+      if camelCount > 1 #don't count a single capital as camel
+        camelBonus = camel[0]
+        exact += 1.5 * wex * camelBonus * camelBonus * (1.0 + tau / (tau + camel[1]))
+
+    return exact * sz
+
+  #----------------------------
+  # Abbreviations sequence
+
+  camel = camelPrefix(query, query_lw, subject, subject_lw)
+  camelCount = camel[2]
+  exact = 0
+  if camelCount > 1
+    camelBonus = camel[0]
+    exact += 5 * wex * camelBonus * camelBonus * (1.0 + tau / (tau + camel[1]))
+
+    #Whole query is camelCase abbreviation ? then => bypass
+    if( camelCount == query.length)
+      return exact * sz
+
+  #----------------------------
+  # Individual chars
+  # (Smith Waterman algorithm)
+
+  #Init
+  vRow = new Array(n)
+  seqRow = new Array(n)
+  vmax = 0
+
+  #Fill with 0
+  j = -1
+  while ++j < n
+    vRow[j] = 0
+    seqRow[j] = 0
+
+  i = 0 #1..m-1
+  while ++i < m     #foreach char of query
+
+    v_diag = vRow[0]
+    seq_diag = seqRow[0]
+
+    j = 0 #1..n-1
+    while ++j < n   #foreach char of subject
+
+      #Compute a tentative match
+      if ( query_lw[i - 1] == subject_lw[j - 1] )
+
+        #forward search for a sequence of consecutive char (will apply some bonus for exact casing or complete match)
+        csc = if seq_diag == 0 then countConsecutive(query, query_lw, subject, subject_lw, i - 1, j - 1) else  seq_diag
+        seq_diag = seqRow[j]
+        seqRow[j] = csc
+
+        #determine bonus for matching A[i-1] with B[j-1]
+        align = v_diag + csc * scoreMatchingChar(query, subject, i - 1, j - 1, camelBonus)
+
+      else
+        seq_diag = seqRow[j]
+        seqRow[j] = 0
+        align = 0
+
+      #Compare the score of making a match, a gap in Query (A), or a gap in Subject (B)
+      v_diag = vRow[j]
+      v = vRow[j] = Math.max(align, vRow[j] + we, vRow[j - 1] + we)
+
+      #Record the best score so far
+      if v > vmax
+        vmax = v
+
+
+  return (vmax + exact) * sz
+
+#
+# Compute the bonuses for two chars that are confirmed to matches in a case-insensitive way
+#
+
+scoreMatchingChar = (query, subject, i, j, camelBonus) ->
+  qi = query[i]
+  sj = subject[j]
+
+  #Proper casing bonus
+  bonus = if qi == sj then wc else 0
+
+  #start of string bonus
+  bonus += Math.floor(wst * tau / (tau + j))
+
+  #match IS a separator
+  return ws + bonus if qi of sep_map
+
+  #match is FIRST char ( place a virtual token separator before first char of string)
+  return wa + bonus if  j == 0
+
+  #get previous char
+  prev_s = subject[j - 1]
+
+  #match FOLLOW a separator
+  return wa + bonus if ( prev_s of sep_map)
+
+  #match is Capital in camelCase (preceded by lowercase)
+  return (1 + camelBonus) * wa + bonus if (sj == sj.toUpperCase() and prev_s == prev_s.toLowerCase())
+
+  #normal Match, add proper case bonus
+  return wm + bonus
+
+#
+# Count consecutive
+#
+
+countConsecutive = (query, query_lw, subject, subject_lw, i, j) ->
+  m = query.length
+  n = subject.length
+
+  mi = m - i
+  nj = n - j
+
+  k = if mi < nj then mi else nj
+  sameCase = 0
+
+  sz = -1
+  while (++sz < k and query_lw[i] == subject_lw[j])
+    sameCase++ if (query[i] == subject[j])
+    i++
+    j++
+
+  # exact match bonus (like score IndexOf)
+  if sameCase == m
+    return 5 * m
+  if sz == m
+    return 2 * (sz + sameCase)
+  else
+    return sz + sameCase
 
 
 #
-# Align sequence
+# Count the number of camelCase prefix
+# Note that case insensitive character such as space will count as lowercase.
+# So this handle both "CamelCase" and "Title Case"
+#
+
+camelPrefix = (query, query_lw, subject, subject_lw) ->
+  m = query.length
+  n = subject.length
+
+  count = 0
+  pos = 0
+  sameCase = 0
+
+  i = -1
+  j = -1
+  k = n - 1
+
+  while ++i < m
+
+    qi_lw = query_lw[i]
+
+    while ++j < n
+
+      sj = subject[j]
+      sj_lw = subject_lw[j]
+
+      #Lowecase, continue
+      if(sj == sj_lw) then continue
+
+      else if( qi_lw == sj_lw )
+        #Subject Uppercase, is it a match ?
+
+        #record position
+        #pos = j if count == 0
+        pos += j
+
+        #Is Query Uppercase too ?
+        qi = query[i]
+        count++
+        sameCase++ if( qi == qi.toUpperCase() )
+
+        break
+
+      #End of subject
+      if j == k then return [count + sameCase, pos / (count + 1), count]
+
+      else
+        # Skipped a CamelCase candidate...
+        # Lower quality of the match by increasing first match pos
+        pos += 3
+
+  #end of query
+  return [count + sameCase, pos / (count + 1), count]
+
+
+#----------------------------------------------------------------------
+
+#
+# Align sequence (used for match)
 # Return position of subject that match query.
 #
 
-
-# Directions constants
-STOP = 0
-UP = 1
-LEFT = 2
-DIAGONAL = 3
-
 exports.align = (subject, query, offset = 0) ->
-
   m = query.length + 1
   n = subject.length + 1
 
@@ -426,7 +393,7 @@ exports.align = (subject, query, offset = 0) ->
   query_lw = query.toLowerCase()
 
   #this is like the consecutive bonus, but for scattered camelCase initials
-  nbc = camelPrefix(subject, subject_lw, query, query_lw)[0]
+  nbc = camelPrefix(query, query_lw, subject, subject_lw)[0]
 
   #Init
   vRow = new Array(n)
@@ -435,9 +402,15 @@ exports.align = (subject, query, offset = 0) ->
   imax = -1
   jmax = -1
 
+  # Directions constants
+  STOP = 0
+  UP = 1
+  LEFT = 2
+  DIAGONAL = 3
+
+  #Traceback matrix
   trace = new Array(m * n)
   pos = n - 1
-
 
   #Fill with 0
   j = -1
@@ -469,10 +442,6 @@ exports.align = (subject, query, offset = 0) ->
       # For the point 3, if char are different in a case insensitive way, score is 0
       # if they are similar, take previous diagonal score (v_diag) and add similarity score.
       # we use similarity(A,B) as an entry point to give various bonuses.
-      #
-      # We also keep track of match context. If we are inside a run of consecutive matches, all bonuses are increased
-      # And so are all penalty. (Encourage matching, discourage non matching)
-
 
       #Compute a tentative match
       if ( query_lw[i - 1] == subject_lw[j - 1] )
@@ -480,17 +449,17 @@ exports.align = (subject, query, offset = 0) ->
         if seq_diag == 0
 
           #forward search for a sequence of consecutive char (will apply some bonus for exact casing or exact match)
-          csc =  countConsecutive(query, query_lw, subject, subject_lw, i-1 , j-1 )
+          csc = countConsecutive(query, query_lw, subject, subject_lw, i - 1, j - 1)
 
         else
           # Verify that previous char is a Match before applying sequence bonus.
           # (this is not done for score because we don't keep trace)
-          csc = if trace[pos-n] == DIAGONAL then seq_diag else 1
+          csc = if trace[pos - n] == DIAGONAL then seq_diag else 1
 
         seq_diag = seqRow[j]
         seqRow[j] = csc
 
-        align =  v_diag + csc*scoreMatchingChar(query, subject, i - 1, j - 1, nbc)
+        align = v_diag + csc * scoreMatchingChar(query, subject, i - 1, j - 1, nbc)
 
       else
         seq_diag = seqRow[j]
@@ -500,7 +469,7 @@ exports.align = (subject, query, offset = 0) ->
       #Compare the score of making a match, a gap in Query (A), or a gap in Subject (B)
       v_diag = vRow[j]
       gapA = vRow[j] + we
-      gapB =  vRow[j - 1] + we
+      gapB = vRow[j - 1] + we
       v = vRow[j] = Math.max(align, gapA, gapB)
 
       # what triggered the best score ?
@@ -543,7 +512,7 @@ exports.align = (subject, query, offset = 0) ->
         j--
         pos--
       when DIAGONAL
-        matches.push j+offset
+        matches.push j + offset
         j--
         i--
         pos -= n + 1

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -306,11 +306,11 @@ exports.basenameScore = (string, query, score) ->
   # No PathSeparator.. no special base to score
   return score if (basePos == -1)
 
-  # Get baseScore bonus
+  # Get basePath score
   baseScore = exports.score(string.substring(basePos + 1, end + 1), query)
 
-  # We'll merge some of that bonus with full path score.
-  # Importance of bonus fade with directory depth until it reach 50/50
+  # We'll merge some of that base path score with full path score.
+  # Mix start at 50/50 then favor of full path as directory depth increase
   alpha = 2.5 / ( 5.0 + countDir(string, end + 1) )
   score = alpha * baseScore + (1 - alpha) * score
 

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -315,9 +315,9 @@ countConsecutive = (query, query_lw, subject, subject_lw, i, j) ->
 
   # exact match bonus (like score IndexOf)
   if sameCase == m
-    return 6 * m
+    return 6 * (m)
   if sz == m
-    return 2 * (sz + sameCase)
+    return 2 * (sz + sameCase )
   else
     return sz + sameCase
 

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -39,14 +39,9 @@ PathSeparator = require('path').sep
 
 #Save above separator in a dictionary for quick lookup
 sep_map = do ->
-
   map = {}
-  k = -1
-  len = separators.length
-  while ++k < len
-    map[separators[k]] = k
-
-  map
+  map[sep] = sep for sep in separators
+  return map
 
 
 # Optional chars

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -14,9 +14,9 @@ PathSeparator = require('path').sep
 wm = 150
 
 #Fading function
-pos_bonus = 20  # The character from 0..pos_bonus receive a bonus for being at the start of string.
-                # max pos bonus occurs at position 0 and have value of pos_bonus^2
-                # The ratio of max pos bonus and wm set importance of start of string position in overall score.
+pos_bonus = 20 # The character from 0..pos_bonus receive a bonus for being at the start of string.
+# max pos bonus occurs at position 0 and have value of pos_bonus^2
+# The ratio of max pos bonus and wm set importance of start of string position in overall score.
 
 tau_size = 50 # Size at which the whole match score is halved.
 tau_depth = 13 # Directory depth at which the full path influence is halved
@@ -68,7 +68,6 @@ exports.score = (string, query, prepQuery = new Query(query), allowErrors = fals
 
 class Query
   constructor: (query) ->
-
     return null unless query?.length
 
     @query = query
@@ -96,23 +95,20 @@ exports.isMatch = isMatch = (subject_lw, query_lw) ->
 
   i = -1
   j = -1
-  k = m - 1
 
   #foreach char of query
   while ++j < n
 
     qj_lw = query_lw[j]
 
-    #continue search in subject from last match
+    # continue search in subject from last match
+    # until first positive or until we reach the end.
     while ++i < m
+      break if subject_lw[i] == qj_lw
 
-      #found match, go to next char of query
-      if subject_lw[i] == qj_lw
-        break
-
-        #last char of query AND no match
-      else if i == k
-        return false
+    # if we reach the end of the string then we do not have a match.
+    # unless we are scanning last char of query and we have a match.
+    if i == m then return (j == n - 1 and subject_lw[i - 1] == qj_lw)
 
 
   return true
@@ -124,7 +120,6 @@ exports.isMatch = isMatch = (subject_lw, query_lw) ->
 #
 
 doScore = (subject, subject_lw, prepQuery, fuzzyWindow) ->
-
   query = prepQuery.query
   query_lw = prepQuery.query_lw
 
@@ -218,7 +213,6 @@ doScore = (subject, subject_lw, prepQuery, fuzzyWindow) ->
 #
 
 isWordStart = (pos, subject, subject_lw) ->
-
   return false if pos < 0
   return true if pos == 0 # match is FIRST char ( place a virtual token separator before first char of string)
   prev_s = subject[pos - 1]
@@ -227,7 +221,6 @@ isWordStart = (pos, subject, subject_lw) ->
 
 
 isWordEnd = (pos, subject, subject_lw, len) ->
-
   return false if pos > len - 1
   return true if  pos == len - 1 # last char of string
   next_s = subject[pos + 1]
@@ -257,9 +250,8 @@ scoreSize = (n, m) ->
 # and structural quality of the pattern on the overall string (word boundary)
 #
 
-exports.scorePattern =  scorePattern = (count, len, sameCase, start, end) ->
-
-  return 1 + sameCase if count is 1
+exports.scorePattern = scorePattern = (count, len, sameCase, start, end) ->
+  return 1 + 2 * sameCase if count is 1
 
   sz = count
 
@@ -292,7 +284,7 @@ exports.scoreCharacter = scoreCharacter = (subject, subject_lw, query, i, j, acr
 
   #match IS a word boundary:
   if isWordStart(i, subject, subject_lw)
-    return posBonus + wm * ( (if acro_score > csc_score then acro_score else csc_score) + 5  )
+    return posBonus + wm * ( (if acro_score > csc_score then acro_score else csc_score) + 10  )
 
   #normal Match, add proper case bonus
   return posBonus + wm * csc_score
@@ -303,7 +295,6 @@ exports.scoreCharacter = scoreCharacter = (subject, subject_lw, query, i, j, acr
 #
 
 exports.scoreConsecutives = scoreConsecutives = (subject, subject_lw, query, query_lw, i, j) ->
-
   m = subject.length
   n = query.length
 
@@ -322,7 +313,7 @@ exports.scoreConsecutives = scoreConsecutives = (subject, subject_lw, query, que
   while (++sz < k and query_lw[++j] == subject_lw[++i])
     sameCase++ if (query[j] == subject[i])
 
-  return 1 + sameCase if sz is 1
+  return 1 + 2 * sameCase if sz is 1
 
   # In a multi word query like "Git Commit" the consecutive sequence can start with a separator, here <space>.
   # We want to register this as a start of word match.
@@ -358,8 +349,7 @@ class AcronymResult
 
 emptyAcronymResult = new AcronymResult(0, 0.1, 0)
 
-exports.scoreAcronyms =  scoreAcronyms = (subject, subject_lw, query, query_lw) ->
-
+exports.scoreAcronyms = scoreAcronyms = (subject, subject_lw, query, query_lw) ->
   m = subject.length
   n = query.length
   return emptyAcronymResult unless m and n

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -1,22 +1,184 @@
-# Original ported from:
 #
-# string_score.js: String Scoring Algorithm 0.1.10
+# Score similarity between two string
 #
-# http://joshaven.com/string_score
-# https://github.com/joshaven/string_score
+#  isMatch: Fast detection if all character of needle is in haystack
+#  score: Find string similarity using a Smith Waterman Gotoh algorithm
+#         Modified to account for programing scenarios (CamelCase folder/file.ext object.property)
 #
-# Copyright (C) 2009-2011 Joshaven Potter <yourtech@gmail.com>
-# Special thanks to all of the contributors listed here https://github.com/joshaven/string_score
-# MIT license: http://www.opensource.org/licenses/mit-license.php
+# Copyright (C) 2015 Jean Christophe Roy and contributors
+# MIT License: http://opensource.org/licenses/MIT
 #
-# Date: Tue Mar 1 2011
+# Previous version of scorer used string_score from Joshaven Potter
+# https://github.com/joshaven/string_score/
 
+
+wm = 10 # base score of making a match
+ws = 30 # bonus of making a separator match
+wa = 20 # bonus of making an acronym match
+wc = 10 # bonus for proper case
+
+wo = -8 # penalty to open a gap
+we = -2 # penalty to continue an open gap (inside a match)
+wh = -0.1 # penalty for haystack size (outside match)
+
+wst = 20 # bonus for match near start of string  (fade one per position until 0)
+wex = 10 # bonus per character of an exact match. If exact coincide with prefix, bonus will be 2*wex, then it'll fade to 1*wex as string happens later.
+
+#Note: separator are likely to trigger both a
+# "acronym" and "proper case" bonus in addition of their own bonus.
+
+
+separators = ' .-_/\\'
 PathSeparator = require('path').sep
 
+separator_map = ->
+  sep_map = {}
+  k = -1
+  while ++k < separators.length
+    sep_map[separators[k]] = k
+
+  sep_map
+
+sep_map = separator_map()
+
+exports.score = score = (subject, query, ignore) ->
+
+  #bypass isMatch will allow inexact match, but will be slower
+  return 0 if !( subject and query and isMatch(query, subject) )
+
+  m = query.length + 1
+  n = subject.length + 1
+
+  #Init
+  vrow = new Array(n)
+  gapArow = new Array(n)
+  gapA = 0
+  gapB = 0
+  vmax = 0
+
+  #DEBUG
+  #VV = []
+
+  #Fill with 0
+  j = -1
+  while ++j < n
+    gapArow[j] = 0
+    vrow[j] = 0
+
+  i = 0 #1..m-1
+  while ++i < m
+    #foreach char of query
+    gapB = 0
+    vd = vrow[0]
+
+    #DEBUG
+    #VV[i] = []
+
+    j = 0 #1..n-1
+    while ++j < n
+      #foreach char of subject
+
+      # Score the options
+      gapA = gapArow[j] = Math.max(gapArow[j] + we, vrow[j] + wo)
+      gapB = Math.max(gapB + we, vrow[j - 1] + wo)
+      align = vd + char_score(query, subject, i - 1, j - 1)
+      vd = vrow[j]
+
+      #Get the best option
+      v = vrow[j] = Math.max(align, gapA, gapB, 0)
+
+      #DEBUG
+      #VV[i][j] = v
+
+      #Record best score
+      if v > vmax
+        vmax = v
+
+  #DEBUG
+  #console.log(query,subject)
+  #console.table(VV);
+
+
+  #haystack penalty
+  vmax = Math.max(vmax / 2, vmax + wh * (n - m))
+
+  #sustring bonus, start of string bonus
+  vmax += if (p = subject.toLowerCase().indexOf(query.toLowerCase())) > -1 then wex * m * (1.0 + 1.0 / (1.0 + p)) else 0
+
+  return vmax
+
+char_score = (query, subject, i, j) ->
+  qi = query[i]
+  sj = subject[j]
+
+  if qi.toLowerCase() == sj.toLowerCase()
+
+    #Proper casing bonus
+    bonus = if qi == sj then wc else 0
+
+    #start of string bonus
+    bonus += Math.max(wst - j, 0)
+
+    #match IS a separator
+    if qi of sep_map
+      return ws + bonus
+
+    #match is first char ( place a virtual token separator before first char of string)
+    return wa + bonus if ( j == 0 or i == 0)
+
+    #get previous char
+    prev_s = subject[j - 1]
+    prev_q = query[i - 1]
+
+    #match FOLLOW a separator
+    return wa + bonus if ( prev_s of sep_map) or ( prev_q of sep_map )
+
+    #match IS Capital in camelCase (preceded by lowercase)
+    return wa + bonus if (sj == sj.toUpperCase() and prev_s == prev_s.toLowerCase())
+
+    #normal Match, add proper case bonus
+    return wm + bonus
+
+  #No match, best move will be to take a gap in either query or subject.
+  return -Infinity
+
+
+isMatch = (query, subject) ->
+  m = query.length
+  n = subject.length
+
+  if !m or !n or m > n
+    return false
+
+  lq = query.toLowerCase()
+  ls = subject.toLowerCase()
+
+  i = -1
+  j = -1
+  k = n - 1
+
+  while ++i < m
+
+    qi = lq[i]
+
+    while ++j < n
+
+      if ls[j] == qi
+        break
+
+      else if j == k
+        return false
+
+
+  true
+
 exports.basenameScore = (string, query, score) ->
+
+  return 0 if score == 0
   index = string.length - 1
   index-- while string[index] is PathSeparator # Skip trailing slashes
   slashCount = 0
+  baseScore = 0
   lastCharacter = index
   base = null
   while index >= 0
@@ -30,60 +192,14 @@ exports.basenameScore = (string, query, score) ->
         base ?= string
     index--
 
-  # Basename matches count for more.
+  # Basename matches count for more, if improvement.
   if base is string
-    score *= 2
+    baseScore = score
   else if base
-    score += exports.score(base, query)
+    baseScore = Math.max(score, exports.score(base, query))
 
   # Shallow files are scored higher
-  segmentCount = slashCount + 1
-  depth = Math.max(1, 10 - segmentCount)
-  score *= depth * 0.01
+  score += baseScore*( 3.0 + 3.0/(3.0+slashCount) )
+
   score
 
-exports.score = (string, query) ->
-  return 1 if string is query
-
-  # Return a perfect score if the file name itself matches the query.
-  return 1 if queryIsLastPathSegment(string, query)
-
-  totalCharacterScore = 0
-  queryLength = query.length
-  stringLength = string.length
-
-  indexInQuery = 0
-  indexInString = 0
-
-  while indexInQuery < queryLength
-    character = query[indexInQuery++]
-    lowerCaseIndex = string.indexOf(character.toLowerCase())
-    upperCaseIndex = string.indexOf(character.toUpperCase())
-    minIndex = Math.min(lowerCaseIndex, upperCaseIndex)
-    minIndex = Math.max(lowerCaseIndex, upperCaseIndex) if minIndex is -1
-    indexInString = minIndex
-    return 0 if indexInString is -1
-
-    characterScore = 0.1
-
-    # Same case bonus.
-    characterScore += 0.1 if string[indexInString] is character
-
-    if indexInString is 0 or string[indexInString - 1] is PathSeparator
-      # Start of string bonus
-      characterScore += 0.8
-    else if string[indexInString - 1] in ['-', '_', ' ']
-      # Start of word bonus
-      characterScore += 0.7
-
-    # Trim string to after current abbreviation match
-    string = string.substring(indexInString + 1, stringLength)
-
-    totalCharacterScore += characterScore
-
-  queryScore = totalCharacterScore / queryLength
-  ((queryScore * (queryLength / stringLength)) + queryScore) / 2
-
-queryIsLastPathSegment = (string, query) ->
-  if string[string.length - query.length - 1] is PathSeparator
-    string.lastIndexOf(query) is string.length - query.length

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -126,6 +126,9 @@ exports.basenameScore = (subject, query, fullPathScore, subject_lw = subject.toL
   #consumed whole subject ?
   return fullPathScore if (basePos == -1)
 
+  #If fuzzyMaxlen apply, clip to the right  to get as mush of the filename as possible
+  basePos = Math.max(basePos, end - fuzzyMaxlen)
+
   # Get basePath score
   basePos++
   end++

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -15,7 +15,7 @@
 wm = 100 # base score of making a match
 wc = 200 # bonus for proper case
 
-wa = 300 # bonus of making an acronym match
+wa = 400 # bonus of making an acronym match
 ws = 200 # bonus of making a separator match
 
 we = -10 # penalty to skip a letter inside a match (vs free to skip around the match)
@@ -315,7 +315,7 @@ countConsecutive = (query, query_lw, subject, subject_lw, i, j) ->
 
   # exact match bonus (like score IndexOf)
   if sameCase == m
-    return 5 * m
+    return 6 * m
   if sz == m
     return 2 * (sz + sameCase)
   else

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -180,7 +180,7 @@ exports.basenameScore = (string, query, score) ->
 
   basePos = string.lastIndexOf(PathSeparator, end)
   baseScore = if (basePos == -1) then score else Math.max(score, exports.score(string.substring(basePos + 1, end+1), query))
-  score = 0.25*score + 0.75*baseScore
+  score = 0.15*score + 0.85*baseScore
 
   score
 

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -351,7 +351,6 @@ abbrPrefix = (query, query_lw, subject, subject_lw) ->
   while ++i < m
 
     qi_lw = query_lw[i]
-
     while ++j < n
 
       sj = subject[j]
@@ -383,6 +382,9 @@ abbrPrefix = (query, query_lw, subject, subject_lw) ->
 
       else if sj of sep_map
         followSeparator = true
+
+    #all of subject is consumed.
+    if j==k then break
 
 
   #a single char is not an acronym

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -108,8 +108,10 @@ exports.score = score = (subject, query, ignore) ->
   #haystack penalty
   vmax = Math.max(0.5 * vmax, vmax + wh * (n - m))
 
-  #last position, the +1s cancel out
-  lpos = m - n - 1
+  # last position, the +1s cancel out
+  # for both the "length=<last index>+1" and the buffer=length+1
+  # also m is query, so smallest of both number
+  lpos = n - m
 
   #sustring bonus, start of string bonus
   if ( p = subject_lw.indexOf(query_lw)) > -1

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -112,7 +112,7 @@ exports.score = score = (subject, query, ignore) ->
   lpos = m - n - 1
 
   #sustring bonus, start of string bonus
-  if ( p = subject.toLowerCase().indexOf(query.toLowerCase())) > -1
+  if ( p = subject_lw.indexOf(query_lw)) > -1
     vmax += wex * m * (1.0 + 5.0 / (5.0 + p))
 
     #sustring happens right after a separator (prefix)

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -246,7 +246,10 @@ exports.score = score = (subject, query) ->
 
       #Compare the score of making a match, a gap in Query (A), or a gap in Subject (B)
       v_diag = vRow[j]
-      v = vRow[j] = Math.max(align, vRow[j] + we, vRow[j - 1] + we)
+      gapA = vRow[j] + we
+      gapB = vRow[j - 1] + we
+      gap = if(gapA > gapB) then gapA else gapB
+      v = vRow[j] = if(align > gap) then align else gap
 
       #Record the best score so far
       if v > vmax
@@ -334,6 +337,7 @@ abbrPrefix = (query, query_lw, subject, subject_lw) ->
 
   m = query.length
   n = subject.length
+  return [0,0,0] unless m and n
 
   count = 0
   pos = 0
@@ -342,7 +346,6 @@ abbrPrefix = (query, query_lw, subject, subject_lw) ->
   i = -1
   j = -1
   k = n - 1
-
 
   while ++i < m
 
@@ -480,7 +483,8 @@ exports.align = (subject, query, offset = 0) ->
       v_diag = vRow[j]
       gapA = vRow[j] + we
       gapB = vRow[j - 1] + we
-      v = vRow[j] = Math.max(align, gapA, gapB)
+      gap = if(gapA > gapB) then gapA else gapB
+      v = vRow[j] = if(align > gap) then align else gap
 
       # what triggered the best score ?
       #In case of equality, taking gapB get us closer to the start of the string.

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -8,50 +8,29 @@
 # Copyright (C) 2015 Jean Christophe Roy and contributors
 # MIT License: http://opensource.org/licenses/MIT
 
-
-wm = 100 # base score of making a match
-wc = 200 # bonus for proper case
-
-wa = 400 # bonus of making an acronym match
-ws = 200 # bonus of making a separator match
-
-we = -10 # penalty to skip a letter inside a match (vs free to skip around the match)
-
-wst = 100 # bonus for match near start of string
-wex = 1000 # bonus per character of an exact match. If exact coincide with prefix, bonus will be 2*wex, then it'll fade to 1*wex as string happens later.
-
-#Note: extra zeros are there to allow rounding the fading bonus function to an integer value.
-
-#
-# Fading function
-#
-# f(x) = tau / ( tau + x) will be used for bonus that fade with position and to to penalize larger haystack.
-# tau is the value of x, for which f(x) = 0.5*f(0) = 0.5
-
-tau = 15
-
-#
-# Separators
-#
-
-separators = ' .-_/\\'
 PathSeparator = require('path').sep
 
-#Save above separator in a dictionary for quick lookup
-sep_map = do ->
-  map = {}
-  map[sep] = sep for sep in separators
-  return map
+#Base point for a single character match
+wm = 150
 
+#Fading function
+pos_bonus = 20  # The character from 0..pos_bonus receive a bonus for being at the start of string.
+                # max pos bonus occurs at position 0 and have value of pos_bonus^2
+                # The ratio of max pos bonus and wm set importance of start of string position in overall score.
 
-# Optional chars
-# Some characters of query char MUST be in subject,
-# Others COULD be there or not, better Score if they are, but don't block isMatch.
+tau_size = 50 # Size at which the whole match score is halved.
+tau_depth = 13 # Directory depth at which the full path influence is halved
+
+# There is a compromise where user expects better pattern to win despite being
+# in a longer string, later in the string, deeper directory etc.
 #
-# Interchangeable are,
-# - word separator,
-# - backward/forward slashes (to support multiple OS and php namespace)
-# - colon (to support Rails  namespace)
+# The knob are should be adjusted to they are as strong as possible without any test failing.
+# This mean some test will barely pass. And making change might require a re-tuning of those number.
+
+
+#
+# Optional chars
+#
 
 opt_char_re = /[ _\-:\/\\]/g
 
@@ -59,20 +38,53 @@ exports.coreChars = coreChars = (query) ->
   return query.replace(opt_char_re, '')
 
 #
-# Search window
-# string_match compute the score using first occurrence of character.
-# we'll consider all occurrences, but limit this search of the best occurrence to
-# a window at the start of the string. This mostly concern deeply nested path
-# and they receive a special treatment for baseName.
+# Search windows for fuzzy matching.
 #
-# Exact match will still continue to search full string.
+# IsMatch & Exact Matches (IndexOf & Acronym) use the full string.
+#
+# But character per character optimal alignment is expensive
+# So we use a search window at the start of the string to control cost.
 #
 
-fuzzyMaxlen = 64
+exports.defaultSearchWindow = 64
+
+#
+# Main export
+#
+# Manage the logic of testing if there's a match and calling the main scoring function
+# Also manage scoring a path and optional character.
+
+exports.score = (string, query, prepQuery = new Query(query), allowErrors = false, fuzzyWindow = exports.defaultSearchWindow) ->
+  string_lw = string.toLowerCase()
+  return 0 unless allowErrors or exports.isMatch(string_lw, prepQuery.core_lw)
+  score = doScore(string, string_lw, prepQuery, fuzzyWindow)
+  return Math.floor(basenameScore(string, string_lw, prepQuery, score, fuzzyWindow))
+
+
+#
+# Query object
+#
+
+
+class Query
+  constructor: (query) ->
+
+    return null unless query?.length
+
+    @query = query
+    @query_lw = query.toLowerCase()
+    @core = coreChars(query)
+    @core_lw = @core.toLowerCase()
+    @depth = countDir(query, query.length)
+
+
+exports.prepQuery = (query) ->
+  return new Query(query)
+
 
 #
 # isMatch:
-# Are all characters of query in subject, in proper order
+# Are all characters of query in subject, in proper order ?
 #
 
 exports.isMatch = isMatch = (subject_lw, query_lw) ->
@@ -94,237 +106,204 @@ exports.isMatch = isMatch = (subject_lw, query_lw) ->
     #continue search in subject from last match
     while ++i < m
 
-      #found match, goto next char of query
+      #found match, go to next char of query
       if subject_lw[i] == qj_lw
         break
 
-      #last char of query AND no match
+        #last char of query AND no match
       else if i == k
         return false
 
 
   return true
 
-#----------------------------------------------------------------------
-
-#
-# Score adjustment for path
-#
-
-exports.basenameScore = (subject, query, fullPathScore, subject_lw = subject.toLowerCase(), query_lw = query.toLowerCase()) ->
-  return 0 if fullPathScore == 0
-
-  # Skip trailing slashes
-  end = subject.length - 1
-  end-- while subject[end] is PathSeparator
-
-  # Get position of basePath of subject. If no PathSeparator, no base path exist.
-  basePos = subject.lastIndexOf(PathSeparator, end)
-
-  # Get the number of folder in query
-  qdepth = countDir(query, query.length)
-
-  # Get that many folder from subject
-  while(basePos > -1 && qdepth--)
-    basePos = subject.lastIndexOf(PathSeparator, basePos-1)
-
-  #consumed whole subject ?
-  return fullPathScore if (basePos == -1)
-
-  #If fuzzyMaxlen apply, clip to the right  to get as mush of the filename as possible
-  basePos = Math.max(basePos, end - fuzzyMaxlen)
-
-  # Get basePath score
-  basePos++
-  end++
-  basePathScore = score(subject[basePos...end], query, subject_lw[basePos...end], query_lw)
-
-  # We'll merge some of that base path score with full path score.
-  # Mix start favoring base Path then favor full path as directory depth increase
-  # Note that base Path test are more nested than original, so we have to compensate one level of nesting.
-
-  alpha = 0.5 * 2 * tau / ( 2 * tau + countDir(subject, end + 1) )
-  return  alpha * basePathScore + (1 - alpha) * fullPathScore
-
-#
-# Count number of folder in a path.
-# (skip consecutive slashes)
-
-exports.countDir = countDir = (path, end) ->
-  return 0 if end < 1
-
-  count = 0
-  i = -1
-  while ++i < end
-
-    p = path[i]
-    if (p == PathSeparator)
-      ++count
-      while ++i < end and path[i] == PathSeparator
-        continue
-
-  return count
 
 #----------------------------------------------------------------------
-
 #
 # Main scoring algorithm
 #
 
-exports.score = score = (subject, query, subject_lw = subject.toLowerCase(), query_lw = query.toLowerCase()) ->
+doScore = (subject, subject_lw, prepQuery, fuzzyWindow) ->
+
+  query = prepQuery.query
+  query_lw = prepQuery.query_lw
+
   m = subject.length
   n = query.length
 
-  #haystack size penalty
-  sz = 4 * tau / (4 * tau + m)
+  sz = scoreSize(n, m)
 
   #----------------------------
   # Abbreviations sequence
 
-  abbr = abbrPrefix(subject, subject_lw, query, query_lw)
-  abbrBonus = abbr.bonus
-  exact = 2 * wex * abbrBonus * abbrBonus * (1.0 + tau / (tau + abbr.pos))
+  acro = scoreAcronyms(subject, subject_lw, query, query_lw)
+  acro_score = acro.score
 
-  #Whole query is abbreviation ? then => bypass
-  if( abbr.count == query.length)
-    return 2 * exact * sz
+  # Whole query is abbreviation ?
+  # => use that as score
+  if( acro.count == n)
+    return 2 * n * ( wm * acro_score + scorePosition(acro.pos) ) * sz
 
   #----------------------------
-  # Exact Match
-  # => bypass
+  # Exact Match ?
+  # => use that as score
 
   pos = subject_lw.indexOf(query_lw)
   if pos > -1
-
-    #bonus per consecutive char grow with number of consecutive
-    #so this need to be squared to stay on top.
-    base = wex * n * n
-
-    pos2 = subject.indexOf(query, pos)
-    if( pos2 > -1)
-      #Substring is ExactCase
-      #Search start at pos, because case-sensitive occurrence cannot happens before case-insensitive one.
-      exact += 3 * base
-      pos = pos2 #When we can, use ExactCase position for position based bonus.
-
-    #base bonus + position decay
-    exact += base * (1.0 + tau / (tau + pos))
-
-    #sustring happens right after a separator (prefix)
-    exact += 5 * base if (pos == 0 or subject[pos - 1] of sep_map)
-
-    #sustring happens right before a separator (suffix)
-    exact += base if (pos == m - n or subject[pos + n] of sep_map)
-
-    # Test for abbreviation.
-    #abbr = abbrPrefix(subject, subject_lw, query, query_lw)
-    #abbrBonus = abbr.bonus
-    #exact += 1.5 * wex * abbrBonus * abbrBonus * (1.0 + tau / (tau + abbr.pos))
-
-    return exact * sz
+    return 2 * n * (  wm * scoreExactMatch(subject, subject_lw, query, pos, n, m) + scorePosition(pos) ) * sz
 
 
   #----------------------------
-  # Individual chars
+  # Individual characters
   # (Smith Waterman algorithm)
 
   #max string size for O(m*n) best match search
-  m = fuzzyMaxlen if m > fuzzyMaxlen
-  n = fuzzyMaxlen if n > fuzzyMaxlen
+  m = fuzzyWindow if m > fuzzyWindow
+  n = fuzzyWindow if n > fuzzyWindow
 
   #Init
-  vRow = new Array(n)
-  seqRow = new Array(n)
-  vmax = 0
+  score_row = new Array(n)
+  csc_row = new Array(n)
 
   #Fill with 0
   j = -1
   while ++j < n
-    vRow[j] = 0
-    seqRow[j] = 0
+    score_row[j] = 0
+    csc_row[j] = 0
 
-  i = -1 #1..m-1
-  while ++i < m     #foreach char of subject
+  i = -1 #0..m-1
+  while ++i < m     #foreach char si of subject
 
-    v = 0
-    v_diag = 0
-    seq_diag = 0
+    score = 0
+    score_diag = 0
+    csc_diag = 0
     si_lw = subject_lw[i]
 
-    j = -1 #1..n-1
-    while ++j < n   #foreach char of query
+    j = -1 #0..n-1
+    while ++j < n   #foreach char qj of query
+
+      #reset score
+      csc_score = 0
+      align = 0
 
       #Compute a tentative match
       if ( query_lw[j] == si_lw )
 
-        #forward search for a sequence of consecutive char (will apply some bonus for exact casing or complete match)
-        seq = if seq_diag == 0 then scoreMatchingSequence(subject, subject_lw, query, query_lw, i, j) else  seq_diag
-        seq_diag = seqRow[j]
-        seqRow[j] = seq
+        # Forward search for a sequence of consecutive char
+        csc_score = if csc_diag > 0  then csc_diag else scoreConsecutives(subject, subject_lw, query, query_lw, i, j)
 
-        #determine bonus for matching A[i] with B[j]
-        align = v_diag + seq * scoreMatchingChar(subject, subject_lw, query, i, j, abbrBonus)
+        # Determine bonus for matching A[i] with B[j]
+        align = score_diag + scoreCharacter(subject, subject_lw, query, i, j, acro_score, csc_score)
 
-      else
-        seq_diag = seqRow[j]
-        seqRow[j] = 0
-        align = 0
+      #Prepare next sequence & match score.
+      score_diag = score_row[j]
+      csc_diag = csc_row[j]
 
       #Compare the score of making a match, a gap in Query (A), or a gap in Subject (B)
-      v_diag = vRow[j]
-      gap = we + if(v > v_diag) then v else v_diag
-      v = vRow[j] = if(align > gap) then align else gap
+      gap = if(score > score_diag) then score else score_diag
 
-      #Record the best score so far
-      if v > vmax
-        vmax = v
+      if(align > gap)
+        score_row[j] = score = align
+        csc_row[j] = csc_score
+      else
+        score_row[j] = score = gap
+        csc_row[j] = 0 #If we do not use this character reset consecutive sequence.
+
+  return score * sz
+
+#
+# Boundaries
+#
+# Is the character at the start of a word, end of the word, or a separator ?
+#
+
+isWordStart = (pos, subject, subject_lw) ->
+
+  return false if pos < 0
+  return true if pos == 0 # match is FIRST char ( place a virtual token separator before first char of string)
+  prev_s = subject[pos - 1]
+  return isSeparator(prev_s) or # match FOLLOW a separator
+      (  subject[pos] != subject_lw[pos] and prev_s == subject_lw[pos - 1] ) # match is Capital in camelCase (preceded by lowercase)
 
 
-  return (vmax + exact) * sz
+isWordEnd = (pos, subject, subject_lw, len) ->
+
+  return false if pos > len - 1
+  return true if  pos == len - 1 # last char of string
+  next_s = subject[pos + 1]
+  return isSeparator(next_s) or # pos is followed by a separator
+      ( subject[pos] == subject_lw[pos] and next_s != subject_lw[pos + 1] ) # pos is lowercase, followed by uppercase
+
+# This is MUCH faster than `c in separator_list` or `c of separator_map`
+# cut about 30% of processing time on worst case scenario
+
+isSeparator = (c) ->
+  return c == ' ' or c == '.' or c == '-' or c == '_' or c == '/' or c == '\\'
+
+
+scorePosition = (pos) ->
+  return 0 if pos > pos_bonus
+  sc = pos_bonus - pos
+  return sc * sc
+
+scoreSize = (n, m) ->
+  # Size penalty, use the difference of size (m-n)
+  return tau_size / ( tau_size + Math.abs(m - n))
+
+
+#
+# Shared scoring logic between exact match, consecutive & acronym
+# Ensure pattern length dominate the score then refine to take into account case-sensitivity
+# and structural quality of the pattern on the overall string (word boundary)
+#
+
+exports.scorePattern =  scorePattern = (count, len, sameCase, start, end) ->
+
+  return 1 + sameCase if count is 1
+
+  sz = count
+
+  bonus = 6 # to Enforce size ordering, this should be as large other bonus combined
+  bonus += 2 if( sameCase == count )
+  bonus += 3 if start
+  bonus += 1 if end
+
+  if( count == len) #when we match 100% of query we allow to break the size ordering.
+    if start
+      if( sameCase == len )
+        sz += 2
+      else
+        sz += 1
+    if end
+      bonus += 1
+
+  return sameCase + sz * ( sz + bonus )
+
 
 #
 # Compute the bonuses for two chars that are confirmed to matches in a case-insensitive way
 #
 
-scoreMatchingChar = (subject, subject_lw, query, i, j, abbrBonus) ->
+exports.scoreCharacter = scoreCharacter = (subject, subject_lw, query, i, j, acro_score, csc_score) ->
 
-  si = subject[i]
-  qj = query[j]
-
-  #Proper casing bonus
-  bonus = if qj == si then wc else 0
 
   #start of string bonus
-  bonus += Math.floor(wst * tau / (tau + i))
+  posBonus = scorePosition(i)
 
-  #match IS a separator
-  return ws + bonus if si of sep_map
-
-  acn = wa * (1 + abbrBonus)
-
-  #match is FIRST char ( place a virtual token separator before first char of string)
-  return acn + bonus if  i == 0
-
-  #get previous char
-  prev_s = subject[i - 1]
-
-  #match FOLLOW a separator
-  return acn + bonus if ( prev_s of sep_map)
-
-  #match is Capital in camelCase (preceded by lowercase)
-  return acn + bonus if (si != subject_lw[i] and prev_s == subject_lw[i-1])
+  #match IS a word boundary:
+  if isWordStart(i, subject, subject_lw)
+    return posBonus + wm * ( (if acro_score > csc_score then acro_score else csc_score) + 5  )
 
   #normal Match, add proper case bonus
-  return wm + bonus
+  return posBonus + wm * csc_score
+
 
 #
-# score the quality of a match Neighbourhood
-# mostly using consecutive characters count and proper case.
+# Forward search for a sequence of consecutive character.
 #
-# use the fact query_lw[i] == subject_lw[j]
-# has been checked before entering.
 
-scoreMatchingSequence = (subject, subject_lw, query, query_lw, i, j) ->
+exports.scoreConsecutives = scoreConsecutives = (subject, subject_lw, query, query_lw, i, j) ->
+
   m = subject.length
   n = query.length
 
@@ -332,52 +311,58 @@ scoreMatchingSequence = (subject, subject_lw, query, query_lw, i, j) ->
   nj = n - j
   k = if mi < nj then mi else nj
 
+  startPos = i #record start position
   sameCase = 0
-  sz = 0 #sz will be one more than the last qi==sj
+  sz = 0 #sz will be one more than the last qi == sj
 
+  # query_lw[i] == subject_lw[j] has been checked before entering
+  # now do case sensitive check.
   sameCase++ if (query[j] == subject[i])
+
   while (++sz < k and query_lw[++j] == subject_lw[++i])
     sameCase++ if (query[j] == subject[i])
 
+  return 1 + sameCase if sz is 1
 
-  # most of the sequences are not exact matches
-  if sz < n
-    return 3 * sz if sz == sameCase #Give a bonus for no case error.
-    return sz + sameCase #general case
-
-  #exact case-sensitive match
-  if sameCase == n
-    return 8 * n
-
-  #exact case-insensitive match (assert sz == n)
-  return 2 * (sz + sameCase )
+  # In a multi word query like "Git Commit" the consecutive sequence can start with a separator, here <space>.
+  # We want to register this as a start of word match.
+  start = isWordStart(startPos, subject, subject_lw) or isSeparator(subject_lw[startPos])
+  end = isWordEnd(i, subject, subject_lw, m)
+  return scorePattern(sz, n, sameCase, start, end)
 
 
 #
-# Count the number of abbreviation prefix
-# Normal char use help of a matching context to determine which one should we take.
-# That context is basically the length of the consecutive run they are part of.
-#
-# This mirror the idea of consecutive run length,
-# but compute consecutive of the abbreviated match
-# ThisIsTest -> tst
-#
-# This handle "CamelCase" , "Title Case" "snake_case"
+# Compute the score of an exact match at position pos.
 #
 
-class AbbrInfo
-  constructor: (@bonus, @pos, @count) ->
+exports.scoreExactMatch = scoreExactMatch = (subject, subject_lw, query, pos, n, m) ->
 
-abbrInfo0 = new AbbrInfo(0, 0.1, 0)
+  #Exact case bonus.
+  i = -1
+  sameCase = 0
+  while (++i < n)
+    if (query[pos + i] == subject[i])
+      sameCase++
 
-abbrPrefix = (subject, subject_lw, query, query_lw) ->
+  start = isWordStart(pos, subject, subject_lw) or isSeparator(subject_lw[pos])
+  end = isWordEnd(pos + n - 1, subject, subject_lw, m)
+  return scorePattern(n, n, sameCase, start, end)
+
+
+#
+# Acronym prefix
+#
+
+class AcronymResult
+  constructor: (@score, @pos, @count) ->
+
+emptyAcronymResult = new AcronymResult(0, 0.1, 0)
+
+exports.scoreAcronyms =  scoreAcronyms = (subject, subject_lw, query, query_lw) ->
 
   m = subject.length
   n = query.length
-  return abbrInfo0 unless m and n
-
-  #Abbreviation is a fuzzy match
-  m = fuzzyMaxlen if m > fuzzyMaxlen
+  return emptyAcronymResult unless m and n
 
   count = 0
   pos = 0
@@ -394,174 +379,88 @@ abbrPrefix = (subject, subject_lw, query, query_lw) ->
 
     while ++i < m
 
-      si_lw = subject_lw[i]
-
       #test if subject match
-      if(qj_lw == si_lw)
+      if(qj_lw == subject_lw[i])
 
-        # Is it CamelCase ?
-        # 1) si is Uppercase ( different from si.toLowerCase() ) AND
-        # 2) j is first char or lowercase
-        #
-        # Is it snake_case ?
-        # 1) j is first char or subject[j-1] is separator
-
-        si = subject[i]
-        prev_s = if i == 0 then si else subject[i - 1]
-
-        if  i == 0 or ( prev_s of sep_map ) or (si != si_lw and prev_s == subject_lw[i - 1] )
-
-          #record position and increase count
+        # subject match.. test if we have an acronym
+        # if so, record result & break to next char of query.
+        if  isWordStart(i, subject, subject_lw)
+          sameCase++ if ( query[j] == subject[i] )
           pos += i
           count++
-
-          #Is it sameCase ?
-          sameCase++ if ( query[j] == si )
-
           break
 
-    #all of subject is consumed.
+    #all of subject is consumed, stop processing the query.
     if i == k then break
 
   #all of query is consumed.
   #a single char is not an acronym (also prevent division by 0)
   if(count < 2)
-    return abbrInfo0
+    return emptyAcronymResult
 
-  return new AbbrInfo(count + sameCase, pos / count, count)
+  score = scorePattern(count, n, sameCase, true, false)
+  return new AcronymResult(score, pos / count, count)
 
 
 #----------------------------------------------------------------------
 
 #
-# Align sequence (used for match)
-# Return position of subject that match query.
+# Score adjustment for path
 #
 
-exports.align = (subject, query, offset = 0) ->
-  m = subject.length
-  n = query.length
-
-  #max string size for O(m*n) best match search
-  m = fuzzyMaxlen if m > fuzzyMaxlen
-  n = fuzzyMaxlen if n > fuzzyMaxlen
-
-  subject_lw = subject.toLowerCase()
-  query_lw = query.toLowerCase()
-
-  #this is like the consecutive bonus, but for scattered camelCase initials
-  abbrBonus = abbrPrefix(subject, subject_lw, query, query_lw).bonus
-
-  #Init
-  vRow = new Array(n)
-  seqRow = new Array(n)
-  vmax = 0
-  imax = -1
-  jmax = -1
-
-  # Directions constants
-  STOP = 0
-  UP = 1
-  LEFT = 2
-  DIAGONAL = 3
-
-  #Traceback matrix
-  trace = new Array(m * n)
-  pos = -1
-
-  #Fill with 0
-  j = -1
-  while ++j < n
-    vRow[j] = 0
-    seqRow[j] = 0
-
-  i = -1 #1..m-1
-  while ++i < m #foreach char of subject
-
-    v = 0
-    v_diag = 0
-    seq_diag = 0
-    si_lw = subject_lw[i]
-
-    j = -1 #1..n-1
-    while ++j < n #foreach char of query
-
-      #Compute a tentative match
-      if ( query_lw[j] == si_lw )
-
-        if seq_diag == 0
-          # forward search for a sequence of consecutive char
-          # (will apply some bonus for exact casing or matching the whole query)
-          seq = scoreMatchingSequence(subject, subject_lw, query, query_lw, i, j)
-
-        else
-          # Verify that previous char is a Match before applying sequence bonus.
-          # (this is not done for score because we don't keep trace)
-          seq = if pos >= n and trace[pos - n] == DIAGONAL then seq_diag else 1
+basenameScore = (subject, subject_lw, prepQuery, fullPathScore, fuzzyWindow) ->
+  return 0 if fullPathScore == 0
 
 
-        seq_diag = seqRow[j]
-        seqRow[j] = seq
+  # Skip trailing slashes
+  end = subject.length - 1
+  end-- while subject[end] is PathSeparator
 
-        #determine bonus for matching A[i] with B[j]
-        align = v_diag + seq * scoreMatchingChar(subject, subject_lw, query, i, j, abbrBonus)
+  # Get position of basePath of subject.
+  basePos = subject.lastIndexOf(PathSeparator, end)
 
-      else
-        seq_diag = seqRow[j]
-        seqRow[j] = 0
-        align = 0
+  #If no PathSeparator, no base path exist.
+  return fullPathScore if (basePos == -1)
 
-      #Compare the score of making a match, a gap in Query (A), or a gap in Subject (B)
-      v_diag = vRow[j]
-      gapA = v_diag + we
-      gapB = v + we
-      gap = if(gapA > gapB) then gapA else gapB
-      v = vRow[j] = if(align > gap) then align else gap
+  # Get the number of folder in query
+  depth = prepQuery.depth
 
-      # what triggered the best score ?
-      #In case of equality, taking gapA get us closer to the start of the string.
-      pos++ #pos = i * n + j
-      switch v
-        when 0
-          trace[pos] = STOP
-        when gapA
-          trace[pos] = UP
-        when gapB
-          trace[pos] = LEFT
-        when align
-          trace[pos] = DIAGONAL
-          #Record best score
-          if v > vmax
-            vmax = v
-            imax = i
-            jmax = j
+  # Get that many folder from subject
+  while(depth-- > 0)
+    basePos = subject.lastIndexOf(PathSeparator, basePos - 1)
+    if (basePos == -1) then return fullPathScore #consumed whole subject ?
 
+  #If fuzzyWindow limit apply, clip to the right  to get as much of the filename as possible
+  basePos = Math.max(basePos, end - fuzzyWindow)
 
-  # -------------------
-  # Go back in the trace matrix from imax, jmax
-  # and collect diagonals
+  # Get basePath score
+  basePos++
+  end++
+  basePathScore = doScore(subject[basePos...end], subject_lw[basePos...end], prepQuery, fuzzyWindow)
 
-  i = imax
-  j = jmax
-  pos = i * n + j
-  backtrack = true
-  matches = []
+  # Final score is linear interpolation between base score and full path score.
+  # For low directory depth, interpolation favor base Path then include more of full path as depth increase
+  #
+  # A penalty based on the size of the basePath is applied to fullPathScore
+  # That way, more focused basePath match can overcome longer directory path.
 
-  while backtrack and i >= 0 and j >= 0
-    switch trace[pos]
-      when UP
-        i--
-        pos -= n
-      when LEFT
-        j--
-        pos--
-      when DIAGONAL
-        matches.push i + offset
-        j--
-        i--
-        pos -= n + 1
-      else
-        backtrack = false
+  alpha = 0.5 * tau_depth / ( tau_depth + countDir(subject, end + 1) )
+  return  alpha * basePathScore + (1 - alpha) * fullPathScore * scoreSize(0, 0.5 * (end - basePos))
 
-  matches.reverse()
-  return matches
+#
+# Count number of folder in a path.
+# (consecutive slashes count as a single directory)
+#
+
+exports.countDir = countDir = (path, end) ->
+  return 0 if end < 1
+
+  count = 0
+  i = -1
+  while ++i < end
+    if (path[i] == PathSeparator)
+      ++count
+      while ++i < end and path[i] == PathSeparator
+        continue
+
+  return count

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -402,10 +402,10 @@ exports.scoreAcronyms = scoreAcronyms = (subject, subject_lw, query, query_lw) -
       #test if subject match
       # Only record match that are also start-of-word.
       if qj_lw == subject_lw[i] and isWordStart(i, subject, subject_lw)
-          sameCase++ if ( query[j] == subject[i] )
-          pos += i
-          count++
-          break
+        sameCase++ if ( query[j] == subject[i] )
+        pos += i
+        count++
+        break
 
     #all of subject is consumed, stop processing the query.
     if i == m then break

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -21,8 +21,9 @@ wo = -8 # penalty to open a gap
 we = -2 # penalty to continue an open gap (inside a match)
 wh = -0.1 # penalty for haystack size (outside match)
 
-wst = 20 # bonus for match near start of string  (fade one per position until 0)
-wex = 10 # bonus per character of an exact match. If exact coincide with prefix, bonus will be 2*wex, then it'll fade to 1*wex as string happens later.
+wst = 20  # penalty for match near start of string
+fst = 0.5 # (fade fst per position until 0)
+wex = 10  # bonus per character of an exact match. If exact coincide with prefix, bonus will be 2*wex, then it'll fade to 1*wex as string happens later.
 
 #Note: separator are likely to trigger both a
 # "acronym" and "proper case" bonus in addition of their own bonus.
@@ -103,7 +104,12 @@ exports.score = score = (subject, query, ignore) ->
   vmax = Math.max(vmax / 2, vmax + wh * (n - m))
 
   #sustring bonus, start of string bonus
-  vmax += if (p = subject.toLowerCase().indexOf(query.toLowerCase())) > -1 then wex * m * (1.0 + 1.0 / (1.0 + p)) else 0
+  if ( p = subject.toLowerCase().indexOf(query.toLowerCase())) > -1
+    vmax += wex * m * (1.0 + 1.0 / (1.0 + p))
+
+    #sustring happens right after a separator (double wex bonus)
+    if (p==0 or subject[p-1] of sep_map)
+      vmax += wex*m
 
   return vmax
 
@@ -117,7 +123,7 @@ char_score = (query, subject, i, j) ->
     bonus = if qi == sj then wc else 0
 
     #start of string bonus
-    bonus += Math.max(wst - j, 0)
+    bonus += Math.max(wst - fst*j, 0)
 
     #match IS a separator
     if qi of sep_map

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -107,7 +107,7 @@ exports.score = score = (subject, query, ignore) ->
 
   #test for camelCase
   p = camelPrefix(subject, subject_lw, query, query_lw)
-  exact += 2*wex*p
+  exact += 3*wex*p
 
   #Whole query is camelCase abbreviation ?
   if(p==query.length)

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -115,10 +115,21 @@ exports.basenameScore = (subject, query, fullPathScore, subject_lw = subject.toL
 
   # Get position of basePath of subject. If no PathSeparator, no base path exist.
   basePos = subject.lastIndexOf(PathSeparator, end)
+
+  # Get the number of folder in query
+  qdepth = countDir(query, query.length)
+
+  # Get that many folder from subject
+  while(basePos > -1 && qdepth--)
+    basePos = subject.lastIndexOf(PathSeparator, basePos-1)
+
+  #consumed whole subject ?
   return fullPathScore if (basePos == -1)
 
   # Get basePath score
-  basePathScore = score(subject[basePos + 1 ... end + 1], query, subject_lw[basePos + 1 ... end + 1], query_lw)
+  basePos++
+  end++
+  basePathScore = score(subject[basePos...end], query, subject_lw[basePos...end], query_lw)
 
   # We'll merge some of that base path score with full path score.
   # Mix start favoring base Path then favor full path as directory depth increase
@@ -131,7 +142,7 @@ exports.basenameScore = (subject, query, fullPathScore, subject_lw = subject.toL
 # Count number of folder in a path.
 # (skip consecutive slashes)
 
-countDir = (path, end) ->
+exports.countDir = countDir = (path, end) ->
   return 0 if end < 1
 
   count = 0

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -334,6 +334,7 @@ countConsecutive = (query, query_lw, subject, subject_lw, i, j) ->
 #
 
 abbrPrefix = (query, query_lw, subject, subject_lw) ->
+
   m = query.length
   n = subject.length
 
@@ -345,49 +346,45 @@ abbrPrefix = (query, query_lw, subject, subject_lw) ->
   j = -1
   k = n - 1
 
-  #virtual separator before first char of the string
-  followSeparator = true
 
   while ++i < m
 
     qi_lw = query_lw[i]
+
     while ++j < n
 
-      sj = subject[j]
       sj_lw = subject_lw[j]
 
-      #If uppercase or after a separator character
-      if(sj != sj_lw or followSeparator)
+      #we have a match
+      if(qi_lw == sj_lw)
 
-        followSeparator = false
+        sj = subject[j]
 
-        #is it a match ?
-        if( qi_lw == sj_lw )
+        # Is it CamelCase ?
+        # 1) sj is Uppercase ( different from sj.toLowerCase() ) AND
+        # 2) j is first char or lowercase
+        #
+        # Is it snake_case ?
+        # 1) j is first char or subject[j-1] is separator
 
-          #record position
-          #pos = j if count == 0
+        prev_s = if j==0 then '' else subject[j-1]
+
+        if  j==0  or ( prev_s of sep_map ) or  (sj != sj_lw and prev_s == subject_lw[j-1] )
+
+          #record position and increase count
           pos += j
-
-          #Is Query Uppercase too ?
-          qi = query[i]
           count++
-          sameCase++ if( qi == qi.toUpperCase() )
+
+          #Is it sameCase ?
+          sameCase++ if ( query[i] == sj )
 
           break
-
-        else
-          # Skipped a CamelCase candidate...
-          # Lower quality of the match by increasing first match pos
-          pos += 3
-
-      else if sj of sep_map
-        followSeparator = true
 
     #all of subject is consumed.
     if j==k then break
 
-
-  #a single char is not an acronym
+  #all of query is consumed.
+  #a single char is not an acronym (also prevent division by 0)
   if(count < 2)
     return [0,0,0]
 

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -236,6 +236,7 @@ exports.score = score = (subject, query) ->
   i = -1 #1..m-1
   while ++i < m     #foreach char of subject
 
+    v = 0
     v_diag = 0
     seq_diag = 0
     si_lw = subject_lw[i]
@@ -261,9 +262,7 @@ exports.score = score = (subject, query) ->
 
       #Compare the score of making a match, a gap in Query (A), or a gap in Subject (B)
       v_diag = vRow[j]
-      gapA = v_diag + we
-      gapB = if j == 0 then 0 else vRow[j - 1] + we
-      gap = if(gapA > gapB) then gapA else gapB
+      gap = we + if(v > v_diag) then v else v_diag
       v = vRow[j] = if(align > gap) then align else gap
 
       #Record the best score so far
@@ -470,6 +469,7 @@ exports.align = (subject, query, offset = 0) ->
   i = -1 #1..m-1
   while ++i < m #foreach char of subject
 
+    v = 0
     v_diag = 0
     seq_diag = 0
     si_lw = subject_lw[i]
@@ -505,7 +505,7 @@ exports.align = (subject, query, offset = 0) ->
       #Compare the score of making a match, a gap in Query (A), or a gap in Subject (B)
       v_diag = vRow[j]
       gapA = v_diag + we
-      gapB = if j == 0 then 0 else vRow[j - 1] + we
+      gapB = v + we
       gap = if(gapA > gapB) then gapA else gapB
       v = vRow[j] = if(align > gap) then align else gap
 

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -195,8 +195,10 @@ exports.score = score = (subject, query) ->
     if (p == lpos or subject[p + 1] of sep_map)
       exact += base
 
-    if(subject.indexOf(query) > -1)
+    if(subject.indexOf(query, p) > -1)
       #substring is ExactCase
+      #search start at pos, because case-sensitive occurrence
+      #cannot happens before case-insensitive one.
       exact += 3 * base
 
     else

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -286,7 +286,7 @@ scoreMatchingChar = (subject, subject_lw, query, i, j, abbrBonus) ->
   bonus = if qj == si then wc else 0
 
   #start of string bonus
-  bonus += Math.floor(wst * tau / (tau + j))
+  bonus += Math.floor(wst * tau / (tau + i))
 
   #match IS a separator
   return ws + bonus if si of sep_map

--- a/src/scorer.coffee
+++ b/src/scorer.coffee
@@ -389,7 +389,6 @@ exports.scoreAcronyms = scoreAcronyms = (subject, subject_lw, query, query_lw) -
 
   i = -1
   j = -1
-  k = m - 1
 
   #foreach char of query
   while ++j < n
@@ -403,14 +402,14 @@ exports.scoreAcronyms = scoreAcronyms = (subject, subject_lw, query, query_lw) -
 
         # subject match.. test if we have an acronym
         # if so, record result & break to next char of query.
-        if  isWordStart(i, subject, subject_lw)
+        if isWordStart(i, subject, subject_lw)
           sameCase++ if ( query[j] == subject[i] )
           pos += i
           count++
           break
 
     #all of subject is consumed, stop processing the query.
-    if i == k then break
+    if i == m then break
 
   #all of query is consumed.
   #a single char is not an acronym (also prevent division by 0)


### PR DESCRIPTION
## What Problem are we trying to solve ?

### Score how matched characters relates to one another.

- One of the most complained thing is not being able to find exact match.
- A great source of questionable results come from scattered character, spread a bit randomly in the string.

And we plan to address those issues by scoring run of consecutive characters.
Exact match will be a special case where the run is 100% of the query length.

Up to now match length was used as a proxy for quality. This work reasonably well when subject is a single word, but break when subject contain multiple words, for example see:

- **Core**
- **Co**nt**r**oll**e**r
- Extention**Core**

In `Core` vs `Controller` size is a good indicator of quality, but not so much in `Controller` vs `ExtentionCore`. This is because match compactness mater more than haystack size.


#### Run length / consecutive

So far the examples can be handled by an `indexOf` call. However there are times where a single query can target multiple part of an candidate.

For example when candidate contain multiple words
- `git push` vs `Git Plus: Push`
- `email handler` vs `email/handler.py`

Another example is to jump above common strings. 
- `toLowerCase`
- `toLocaleString`
- `toLocalLowerCase`

We could use a query like `tololo`  to select the third option of these.


### Select character based on score.

The current algorithm always select the first available matching character (leftmost alignment) then try to identify how it should be scored. The problem is that the most interesting instance of a character is not necessarily on the left.

For example on query `itc`, we should match
-  **I**mportance**T**able**C**trl.

Instead leftmost aligement miss the acronym pattern 
- **I**mpor**t**an**c**eTableCtrl.

For query `core` against `controller_core` leftmost alignment miss the consecutive run    
- **co**nt**r**oll**e**r_core 

To handle this we propose to setup the max run-length scoring inside an optimal alignment scheme. (Implemented for example using dynamic programming)

### Accidental acronym bonus.

Fuzzladrin handle acronym by giving a large per character bonus.  Currently a start of word bonus match almost as much as 3 proper case character (or 7 wrong case ones!)

For query install "install" should result be in this order ?
- F**in**d & Replace **S**elec**t** **All**
- Application: **Install**

Here we have '**S**elect **A**ll' boost the score of the first candidate because we match two word-start VS only one for 'install'.

For query "git push", should we order result in that order ?
- "**Git** **P**l**u**s: **S**tage **H**unk" 
- "**Git** Plus: **Push**" 

What about the fact we match 3 start-of-word in `Plus Stage Hunk` ? PSH is very close to '**p**u**sh**'. 

That kind of question arise even more often with optimal selection because the algorithm will lock on those extra acronym points.

What we propose in this PR is that word start-of-word character only have a moderate advantage by themselves. Instead they form strong score by making an acronym pattern with other start-of-word character.

For example with query `push`:
- match against `Plus: Stage Hunk`, we have P + u + SH so group of 1+1+2
- match against `push` single group of 4.
- The substring win for having the largest group

For example with query `psh`:
- match against `Plus: Stage Hunk`, we have PSH so group of 3
- match against `push`, we have p+sh so group of 1+2
- The acronym win for having the largest group.

 
This way we can score both substring and acronym match using the structure of the match. We'll refine the definition of consecutive acronym later.


### Score the context of the match.

Some people proposed to give perfect score to exact case sensitive match. This can be understood because exact match and consecutive are two area where fuzzaldrin is not great.

However should 'sw**itc**h.css' be an exact match for `itc` ? 
Even when we have **I**mportance**T**able**C**trl available ?

Few people will argue against "diag" preferring "diagnostic" to "Diagnostics".

However should `install` prefer "Un**install**" over "**Install**" ? Or should it be the other way around ?  This is a case of case-sensitive match vs start-of-word ...


## Proposed scoring


### 1. Characters are chosen by their ability to form pattern with others.

Pattern can be made of 
 - consecutive letter of the subject, 
 - consecutive letter of the Acronym of subject. 

Start-of-word (acronym) character are special in that they can either make pattern with the rest of the word or other acronym character.

- This replace a situation where acronym character had unconditional large bonus. Now the bonus is still large but conditional to being part of some pattern.

- CamelCase and snake_case acronym are treated exactly the same. They will however get different point for matching uppercase/lowercase query


### 2. Primary score attribute is pattern length.

- A pattern that span 100% of the query length is called an exact match.
 	- There is such a thing as an acronym exact match.

- Because every candidate is expected to match all of query larger group should win against multiple smaller one.
    - Rank of a candidate is the length of it's largest pattern. 
    - When every pattern in a candidate are larger than pattern in a second one, highest rank candidate is said to be dominant.
        - 1 group of 6 >  2 group of 3 > 3 group of 2.
        
	- When some group are larger and some are smaller, highest rank match is said to be semi-dominant.
         - group of 4+2 vs 2 groups of 3. Group of 4 wins agains the first group of 3, group of 2 loose against second group of 3.

### 3. Secondary score attribute is match quality.
  
- Match quality is made of proper-casing and context score
    - Main role of match quality is to order candidate of the same rank.
    - When match is semi-dominant match quality can overcome a rank-1 difference.

- Context score consider where does the match occurs in the subject.
	- Full-word > Start-of-word > End-of-word > Middle-of-word
	- On that list, Acronym pattern score at Start-of-word level. (That is just bellow full-word)

- Proper case is both gradual and absolute.
   - The less error, the better
   - 100% Case Error will be called wrong-case, for example matching a CamelCase acronym using lowercase query.  
   - Exactly 0 error is called CaseSentitive or ExactCase match. 
     They have a special bonus smaller than start-of-word bonus but greater than end-of-word bonus.
     - This allow a start-of-word case sentitive match to overcome a full-word wrong-case match.
     - Also allow to select between a lowercase consecutive and CamelCase acronym using case of query.
     - Make "Installed" win over "Uninstall" because  start-of-word > Exact Case.
       
- **Q:** Why can't you simply add extra length. For example add an extra virtual character for a start-of-word match.
   - **A:** We cannot do that on partial match because then the optimal alignment algorithm will be happy to split word and collect start-of-word bonus like stamp. (See accidental acronym)

- **Q:** Why do you still do it on exact match ?
   - **A:** First once you have matched everything there's no danger of splitting the query, then it's there for exact match to bubble up, despite longer/deeper path. If after more test/tuning we realize it's not needed, we'll be happy to remove it, the less corner case the merrier.

- **Q:** Why are you using lowecase to detect CamelCase ?
  - **A** CamelCase are detected as a switch from lowercase to UPPERCASE. Defining UPPERCASE as not-lowercase, allow case-invariant character to count as lowercase.   A lot of case invariant character are also separator, some are not such as number, and symbol such as `:!=<>()` 

### 4. Tertiary score attributes are subject size, match position and directory depth

- Mostly there to help order match of the same rank and match quality, unless the difference in tertiary attribute is large. 
 	-(Proper definition of large is to be determined using real life example)

- In term of importance of effect it should rank start-of-string > string size > directory depth.


-------------

### Acronym Prefix
More detail on acronym match


The acronym prefix is a group of character that are consecutive in the query and sequential in the acronym of the subject.
That group start at the first character of the query and end at the first error (character not in acronym). 
If there's no error we have an acronym exact match (100% of query is part of acronym)


**For example if we match `ssrb` against `Set Syntax Ruby` we'll score it like so**

````
  012345678901234
 "Set Syntax Ruby"
 "000 SSR0b0 0000"
````

- Acronym scored as start-of-word consecutive rank 3 + an isolated letter.
- Here we have a wrong-case match. "SSRb" or "SSRB" would have case-sensitive points on the acronym pattern (case of isolated letter is not important)
- Position of the equivalent consecutive match is the average position of acronym characters.
- Size of the candidate does not chance.


**Another example is matching `gaa` against `Git Plus: Add All` we'll score it like so**

````
  01234567890123456
 "Git Plus: Add All"
 "000000 GAA00 0000"
````

- here we conveniently allow to skip the `P` of `Plus`.


**Then what about something like "git aa" ?**

This is a current limitation. We do not support acronym pattern outside of the prefix. Mostly for performance reason.
Acronym outside of the acronym prefix will have some bonus, scoring between isolated character and 2 consecutive.
There are multiple thing we can improve if one day we implement a proper multiple word query support, and this is one of them.

### Optional characters

Legacy fuzzaldrin had some support for optional character (Mostly space, see `SpaceRegEx`). Because the scoring do not support errors, the optional character where simply removed from the query.

With this PR, optimal alignment algorithm support an unlimited number of errors. The strict matching requirement is handled by a separate method `isMatch`. The optional character implementation is done by building a subset of query containing only non-optional character (`coreQuery`) and passing that to `isMatch`.

This new way of doing thing means that while some characters are optional, candidate that match those characters will have better score. What this allow is to add characters to the optional list without compromising ranking.

Character that has been added include `-` and `_` because multiple  specs require that we should threat them as space. Also `\` and `:` to support searching a file by PHP and Ruby name-space. Finally `/` to mirror `\` and support a better work flow in a multi-OS environment. 

Finally option `allowErrors` would make any character optional. Expected effect of that would be spell-checker like, but slower match.


### Path scoring

- Score for a path is made of about half score of full path and half score of basename.

- Exact balance between those two set by the directory dept, there is less retrieval effect (importance of basename) for deeper directory

- Full path is penalized twice for size. Once for it's own size, then a second time for size of the basename. This address various demand for shorter basename to win. Extra basename penalty is dampened a bit.

- Basename is scored as if `allowErrors` was set to true. (Fullpath must still pass `isMatch` test) This allow to support query such as `model user` against path `model/user`. Previously, the basename score would be 0 because it would not find `model` inside basename `user`. Variable `queryHasSlashes` sort of addressed this issue, but was inconsistent with usage of `<space>` as folder separator 

- When query has slashes (`path.sep`) the last or last few folder from the path are promoted to the basename. (as many folder from the path as folder in the query)



-------------

## Performance

### Hit Miss Optimization.

A hit occurs when character of query is also in the subject.
 - Every (i,j) such that subject[i] == query[j], in lowercase.

A missed hit occurs when a hit does not improve score.

To guarantee optimal alignment, every hit has to be considered.
However when candidate are long (deep path) & query contains popular character (vowels) , we can spend a huge amount of time scoring accidental hit. 

So we use number of missed hit as a heuristic for unlikely to improve.
Let's score `itc` vs `ImportanceTableControl`

- `I` of `Importance`: First occurrence, improve over none.
- `t` of `Importance`: First occurrence, improve over none.
- `c` of `Importance`: First occurrence, improve over none.
- `T` of `Table` : Acronym match, improve over isolated middle of word.
- `C` of `Control` : Acronym match, improve over isolated middle of word.
- `t` of `Control`: no improvement over acronym `T`: first hit miss.

- After a certain threshold of hit miss we can consider it's unlikely the score will get better 
- Despite above example hit miss optimization do not affect scoring of exact match (sub-string or acronym)
- There are some legitimate use for hit miss, for example while scoring query `Mississippi` each positive match for `s` or `i` may trigger up to 3 hit miss on the other occurrence of that letter in query.

- For that reason we propose counting consecutive hit miss and having maximum one hit miss per character of subject.

**Q:** Does this grantee improvement over leftmost alignment ?
**A:** It'll often be the case but no guarantee on pathological match.
 For example, in query `abcde` against candidate '**abc**abcabcabcabcabcabc_de' we may trigger the miss count before matching `de`. It'll still be registered as a match and probably a good one with `abc` at the start, `de` will be scored as optional characters not present. 

Candidate  'abcabcabcabcabcabc**abcde**' will not have any problem because it does not affect exact match. 

Real example is searching `index` in the benchmark. Where `i`, `n`, `d`, `e` exist scattered in folder name, but x exist in the extension `.txt`. However the whole point of this PR is to prefer structured match to scattered one so this might not be a problem.

### High Positive count mitigation
**[option `maxInners`, disabled by default]**

A lot of the speed of this PR come from the idea that rejection happens often and we need to be very efficient on them to offset slower higher quality match. Unfortunately some query will match against almost everything.

- Fast short-circuit path for exact substring acronym help a lot.
- Missed hit heuristic also help a lot for general purpose match.

However we may still be too slow for interactive time query on large data set. This is why `maxInners` option is provided.

This is the maximum number of positive candidate we collect before sorting and returning the list.

The realization is that a query that match everything on a 50K item data set is unlikely to show anything useful to the user above the fold (say in the first 15 results). 

So then the priority is to detect such case of low quality (low discrimination power) query and report fast to the user so user can refine its query.

A `maxInners` size of about 20% of the list works well. It is not needed on smaller list.


### Benchmark
- All test compare this PR to previous version (legacy)

- The first test `index` is a typical use case, 10% positive, 1/3 of positive are exact match.
  - We are about 2x faster

- Second test `indx` remove exact matches. Just under 2x faster

- Third test `walkdr`, 1% positive, mostly testing `isMatch()`, above 2x faster.

- Fourth test `node`, exact match, 98% positive, bit under 2x faster.

- Test 5 `nm`, exact acronym match, 98% positive, about 10% slower.

- Test 6 `nodemodules` is special in that it use a string that score on almost every candidate, often multiple time per candidate and individuals characters are popular. It also avoid exact match speed-up.
About 2x slower, but unlikely to happens in real life. `maxInners` mitigation cover that case.
````
Filtering 66672 entries for 'index' took 62ms for 6168 results (~10% of results are positive, mix exact & fuzzy)
Filtering 66672 entries for 'index' took 120ms for 6168 results (~10% of results are positive, Legacy method)
======
Filtering 66672 entries for 'indx' took 69ms for 6192 results (~10% of results are positive, Fuzzy match)
Filtering 66672 entries for 'indx' took 126ms for 6192 results (~10% of results are positive, Fuzzy match, Legacy)
======
Filtering 66672 entries for 'walkdr' took 30ms for 504 results (~1% of results are positive, fuzzy)
Filtering 66672 entries for 'walkdr' took 70ms for 504 results (~1% of results are positive, Legacy method)
======
Filtering 66672 entries for 'node' took 112ms for 65136 results (~98% of results are positive, mostly Exact match)
Filtering 66672 entries for 'node' took 213ms for 65136 results (~98% of results are positive, mostly Exact match, Legacy method)
======
Filtering 66672 entries for 'nm' took 60ms for 65208 results (~98% of results are positive, Acronym match)
Filtering 66672 entries for 'nm' took 56ms for 65208 results (~98% of results are positive, Acronym match, Legacy method)
======
Filtering 66672 entries for 'nodemodules' took 602ms for 65124 results (~98% positive + Fuzzy match, [Worst case scenario])
Filtering 66672 entries for 'nodemodules' took 123ms for 13334 results (~98% positive + Fuzzy match, [Mitigation])
Filtering 66672 entries for 'nodemodules' took 295ms for 65124 results (Legacy)
````

**Q:** My results are not as good.
**A:** Run the benchmark a few time, it looks like some optimisation kick in later. (Or CPU on energy efficient device migth need to warm up before some optimisations are activated)



## Prior Art

[Chrome FilePathScore](
https://chromium.googlesource.com/chromium/blink/+/master/Source/devtools/front_end/sources/FilePathScoreFunction.js#70)

[Textmate ranker](https://github.com/textmate/textmate/blob/master/Frameworks/text/src/ranker.cc#L46)

[VIM Command-T ](https://github.com/wincent/command-t/blob/master/ruby/command-t/match.c#L22)

[Selecta](https://github.com/garybernhardt/selecta/blob/master/selecta#L415)

[PeepOpen](https://github.com/topfunky/PeepOpen/blob/master/Classes/Models/FuzzyRecord.rb)

[flx](https://github.com/lewang/flx)


## List of addressed issues

### Exact match vs directory depth.

https://github.com/atom/fuzzaldrin/issues/18
-> actionsServiceSpec

https://github.com/atom/atom/issues/7783
-> usa_spec

### Start of string VS directory depth

https://github.com/atom/fuzzy-finder/issues/57#issuecomment-133531653
-> notification

https://github.com/atom/fuzzy-finder/issues/21#issuecomment-48795958
-> video backbone

### Folder / file query

https://github.com/atom/fuzzy-finder/issues/21#issue-29106280
-> src/app vs destroy_discard

https://github.com/atom/fuzzy-finder/issues/21#issuecomment-46920333
-> email handler

https://github.com/substantial/atomfiles/issues/43
-> model user

### Spread/group vs directory depth

https://github.com/atom/fuzzy-finder/issues/21#issuecomment-138664303
-> controller core

### Initialism

https://github.com/atom/fuzzy-finder/issues/57#issue-42120886
-> itc switch / ImportanceTableCtrl

https://github.com/atom/fuzzy-finder/issues/57#issuecomment-95623924
-> application controller

https://github.com/atom/fuzzaldrin/issues/21
-> fft vs FilterFactorTests

### Accidental Acronym

https://github.com/atom/command-palette/issues/28
-> Install / Find Select All

https://github.com/atom/fuzzaldrin/issues/20#issue-93279352
-> Git Plus Stage Hunk / Git Plus Push


### Case sensitivity

https://github.com/atom/autocomplete-plus/issues/42
-> downloadThread / DownloadTask

https://github.com/atom/fuzzaldrin/issues/17
-> diagnostics / Diagnostic


### Optional Characters

https://github.com/atom/fuzzy-finder/issues/91
https://github.com/atom/fuzzaldrin/issues/24

-> PHP Namespaces, let "\" match "/"
-> (would be nice for config file in mized OS environment too)

https://github.com/atom/fuzzy-finder/pull/51

-> Ruby Namespaces, let "::" match "/"

https://github.com/atom/fuzzy-finder/issues/10
-> SpaceRegex, let " " match "/"
-> was already implemented, posted here to show parallel. 


### Suggestions

https://github.com/atom/fuzzy-finder/issues/21#issue-29106280
-> we implement suggestion of score based on run length
-> todo allow fuzzaldrin to support external knowledge.


