### PR TITLE
Add support for filtering by multiple keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Sort and filter the given candidates by matching them against the given query.
 * `query` - A string query to match each candidate against.
 * `options` - An optional object with the following keys:
   * `key` - The property to use for scoring if the candidates are objects.
+  * `keys` - Array of properties to use for scoring if the candidates are objects.
   * `maxResults` - The maximum numbers of results to return.
 
 Returns an array of candidates sorted by best match against the query.

--- a/spec/filter-spec.coffee
+++ b/spec/filter-spec.coffee
@@ -137,3 +137,29 @@ describe "filtering", ->
         path.join('spec', 'cars.rb')
       ]
       expect(bestMatch(candidates, 'car.rb')).toBe candidates[0]
+
+  describe "when entries are objects", ->
+    it "matches a single key", ->
+      candidates = [
+        { name: 'truck', lang: 'ruby', ext: '.rb' }
+        { name: 'ruby car', lang: 'ruby', ext: '.rb' }
+        { name: 'foo', lang: 'php', ext: '.php' }
+      ]
+      expectedCandidates = candidates.slice(0, 2)
+      results = filter(candidates, 'ruby', keys: ['lang'])
+      expectedResults = filter(candidates, 'ruby', key: 'lang')
+      expect(results.length).toBe 2
+      expect(results).toEqual expectedCandidates
+      expect(results).toEqual expectedResults
+
+    it "matches multiple keys", ->
+      candidates = [
+        { name: 'truck', lang: 'ruby', ext: '.rb' }
+        { name: 'ruby car', lang: 'ruby', ext: '.rb' }
+        { name: 'foo', lang: 'php', ext: '.php' }
+      ]
+      expectedCandidates = candidates.slice(0, 2)
+      results = filter(candidates, 'ruby', keys: ['name', 'lang'])
+      expect(results.length).toBe 2
+      expect(results[0]).toBe expectedCandidates[1]
+      expect(results[1]).toBe expectedCandidates[0]


### PR DESCRIPTION
When working on my Alfred workflow for Atom that uses fuzzaldrin for text matching, I found that it lacked support to filter by multiple keys on objects. I managed by copying and modifying the filter code quite easily though I couldn't help but offer the same changes to fuzzaldrin.